### PR TITLE
Numerous config updates on Bay 3

### DIFF
--- a/opcpa_tpr_config/neh_bay3_config.yaml
+++ b/opcpa_tpr_config/neh_bay3_config.yaml
@@ -145,6 +145,17 @@ lasers:
         TIC_Averaging:
           val: 2000
 
+      cfg_on_time:
+        desc: "On Time (EC 284)"
+        Carbide_PP_Goose:
+          seqcode: 284
+        Carbide_PP:
+          seqcode: 284
+        TIC_Gate:
+          seqcode: 284
+        TIC_Averaging:
+          val: 50
+
     # Allowed goose configs (in TPG seconds) for the given laser
     goose_rate_configs:
       desc: "Goose Rep. Rate"
@@ -202,6 +213,17 @@ lasers:
           seqcode: 273
         TIC_Gate:
           seqcode: 273
+
+      cfg_goose_off_time:
+        desc: "Off Time (EC 285)"
+        Carbide_Goose:
+          seqcode: 285
+        Amphos_Goose:
+          seqcode: 285
+        Carbide_PP_Goose:
+          seqcode: 285
+        TIC_Gate:
+          seqcode: 285
 
     goose_arrival_configs:
       desc: "Goose Arrival"

--- a/opcpa_tpr_config/neh_bay3_config.yaml
+++ b/opcpa_tpr_config/neh_bay3_config.yaml
@@ -57,39 +57,39 @@ lasers:
     # Allowed rep-rate configs (in TPG seconds) for the given laser
     laser_rate_configs:
       desc: "Base Rep. Rate"
-      cfg_130:
-        desc: "130 Hz"
-        Carbide_PP_Goose:
-          seqcode: 256
-        Carbide_PP:
-          seqcode: 256
-        TIC_Gate:
-          seqcode: 256
-        TIC_Averaging:
-          val: 50
-
-      cfg_500:
-        desc: "500 Hz"
-        Carbide_PP_Goose:
-          seqcode: 257
-        Carbide_PP:
-          seqcode: 257
-        TIC_Gate:
-          seqcode: 257
-        TIC_Averaging:
-          val: 50
-
-      cfg_650:
-        desc: "650 Hz"
-        Carbide_PP_Goose:
-          seqcode: 258
-        Carbide_PP:
-          seqcode: 258
-        TIC_Gate:
-          seqcode: 258
-        TIC_Averaging:
-          val: 50
-
+#      cfg_130:
+#        desc: "130 Hz"
+#        Carbide_PP_Goose:
+#          seqcode: 256
+#        Carbide_PP:
+#          seqcode: 256
+#        TIC_Gate:
+#          seqcode: 256
+#        TIC_Averaging:
+#          val: 50
+#
+#      cfg_500:
+#        desc: "500 Hz"
+#        Carbide_PP_Goose:
+#          seqcode: 257
+#        Carbide_PP:
+#          seqcode: 257
+#        TIC_Gate:
+#          seqcode: 257
+#        TIC_Averaging:
+#          val: 50
+#
+#      cfg_650:
+#        desc: "650 Hz"
+#        Carbide_PP_Goose:
+#          seqcode: 258
+#        Carbide_PP:
+#          seqcode: 258
+#        TIC_Gate:
+#          seqcode: 258
+#        TIC_Averaging:
+#          val: 50
+#
       cfg_1300:
         desc: "1300 Hz"
         Carbide_PP_Goose:

--- a/opcpa_tpr_config/neh_bay3_config.yaml
+++ b/opcpa_tpr_config/neh_bay3_config.yaml
@@ -134,6 +134,17 @@ lasers:
         TIC_Averaging:
           val: 500
 
+      cfg_16250:
+        desc: "16250 Hz"
+        Carbide_PP_Goose:
+          seqcode: 271
+        Carbide_PP:
+          seqcode: 271
+        TIC_Gate:
+          seqcode: 271
+        TIC_Averaging:
+          val: 1000
+
       cfg_32500:
         desc: "32500 Hz"
         Carbide_PP_Goose:

--- a/opcpa_tpr_config/opcpa_tpr_config.py
+++ b/opcpa_tpr_config/opcpa_tpr_config.py
@@ -301,8 +301,16 @@ class App(Display):
         arrival: QComboBox widget containing the valid "arrival" rep rate
                  configurations for the laser.
         """
+        # Setup base configuration first
         self.set_device_configuration(las_conf, laser_db, base)
-        self.set_device_configuration(las_conf, laser_db, goose)
+
+        # Don't setup goose config if not using goose
+        arrival_mode = str(arrival.currentText())
+        if arrival_mode != "Goose off":
+            # Modify goose setting after base settings (TIC gate is different)
+            self.set_device_configuration(las_conf, laser_db, goose)
+
+        # Setup arrival conditions
         self.set_device_configuration(las_conf, laser_db, arrival)
 
     def set_device_configuration(self, las_conf, laser_db, cbox):


### PR DESCRIPTION
Adds 16kHz base rate config
Adds "programmable" on time and off time config for base rate and goose rate
Remove undesired base rates less than 1kHz

closes #27 
closes #26 
closes #29 
I think that this also effectively closes #19 because the on time/off time trigger codes could be configured to anything the hutches want. 