### PR TITLE
Update TIC Gate channel, remove un-necessary carbide PP settings

### DIFF
--- a/neh_bay3_db.json
+++ b/neh_bay3_db.json
@@ -117,7 +117,7 @@
         "device_class": "pcdsdevices.tpr.TprTrigger",
         "documentation": "TIC Gate",
         "kwargs": {
-            "channel": 7,
+            "channel": 9,
             "name": "{{name}}",
             "timing_mode": 2
         },

--- a/opcpa_tpr_config/neh_bay3_config.yaml
+++ b/opcpa_tpr_config/neh_bay3_config.yaml
@@ -92,8 +92,6 @@ lasers:
 #
       cfg_1300:
         desc: "1300 Hz"
-        Carbide_PP_Goose:
-          seqcode: 259
         Carbide_PP:
           seqcode: 259
         TIC_Gate:
@@ -103,8 +101,6 @@ lasers:
 
       cfg_2500:
         desc: "2500 Hz"
-        Carbide_PP_Goose:
-          seqcode: 260
         Carbide_PP:
           seqcode: 260
         TIC_Gate:
@@ -114,8 +110,6 @@ lasers:
 
       cfg_3250:
         desc: "3250 Hz"
-        Carbide_PP_Goose:
-          seqcode: 261
         Carbide_PP:
           seqcode: 261
         TIC_Gate:
@@ -125,8 +119,6 @@ lasers:
 
       cfg_8125:
         desc: "8125 Hz"
-        Carbide_PP_Goose:
-          seqcode: 272
         Carbide_PP:
           seqcode: 272
         TIC_Gate:
@@ -136,8 +128,6 @@ lasers:
 
       cfg_16250:
         desc: "16250 Hz"
-        Carbide_PP_Goose:
-          seqcode: 271
         Carbide_PP:
           seqcode: 271
         TIC_Gate:
@@ -147,8 +137,6 @@ lasers:
 
       cfg_32500:
         desc: "32500 Hz"
-        Carbide_PP_Goose:
-          seqcode: 262
         Carbide_PP:
           seqcode: 262
         TIC_Gate:
@@ -158,8 +146,6 @@ lasers:
 
       cfg_on_time:
         desc: "On Time (EC 284)"
-        Carbide_PP_Goose:
-          seqcode: 284
         Carbide_PP:
           seqcode: 284
         TIC_Gate:


### PR DESCRIPTION
The TIC channel needs to be updated for Bay 3, and there were un-necessary settings for the carbide pulse picker in the base rate configs that was causing confusion. This resolves both of those issues. 