### PR TITLE
Bay 2 setup

### DIFF
--- a/neh_bay2_db.json
+++ b/neh_bay2_db.json
@@ -117,7 +117,7 @@
         "device_class": "pcdsdevices.tpr.TprTrigger",
         "documentation": "TIC Gate",
         "kwargs": {
-            "channel": 7,
+            "channel": 9,
             "name": "{{name}}",
             "timing_mode": 2
         },

--- a/opcpa_tpr_config/neh_bay2_config.yaml
+++ b/opcpa_tpr_config/neh_bay2_config.yaml
@@ -2,7 +2,7 @@
 
 main:
     xpm_pv: "DAQ:NEH:XPM:0:SEQCODES"
-    title: "NEH Laser Hall OPCPA Rep. Rate Configuration"
+    title: "NEH Laser Hall Bay 2 OPCPA Rep. Rate Configuration"
 
 lasers:
   bay_3:

--- a/opcpa_tpr_config/neh_bay2_config.yaml
+++ b/opcpa_tpr_config/neh_bay2_config.yaml
@@ -5,9 +5,9 @@ main:
     title: "NEH Laser Hall OPCPA Rep. Rate Configuration"
 
 lasers:
-  bay_2:
+  bay_3:
 
-    laser_desc: "Bay 2 Configuration"
+    laser_desc: "Bay 2 TPR Configuration"
 
     laser_database: "neh_bay2_db.json"
 
@@ -57,140 +57,170 @@ lasers:
     # Allowed rep-rate configs (in TPG seconds) for the given laser
     laser_rate_configs:
       desc: "Base Rep. Rate"
-      cfg_130:
-        desc: "130 Hz"
-        Carbide_PP_Goose:
-          seqcode: 256
-        Carbide_PP:
-          seqcode: 256
-        TIC_Gate:
-          seqcode: 256
-        TIC_Averaging:
-          val: 50
-
-      cfg_500:
-        desc: "500 Hz"
-        Carbide_PP_Goose:
-          seqcode: 257
-        Carbide_PP:
-          seqcode: 257
-        TIC_Gate:
-          seqcode: 257
-        TIC_Averaging:
-          val: 50
-
-      cfg_650:
-        desc: "650 Hz"
-        Carbide_PP_Goose:
-          seqcode: 258
-        Carbide_PP:
-          seqcode: 258
-        TIC_Gate:
-          seqcode: 258
-        TIC_Averaging:
-          val: 50
-
+#      cfg_130:
+#        desc: "130 Hz"
+#        Carbide_PP_Goose:
+#          seqcode: 256
+#        Carbide_PP:
+#          seqcode: 256
+#        TIC_Gate:
+#          seqcode: 256
+#        TIC_Averaging:
+#          val: 50
+#
+#      cfg_500:
+#        desc: "500 Hz"
+#        Carbide_PP_Goose:
+#          seqcode: 257
+#        Carbide_PP:
+#          seqcode: 257
+#        TIC_Gate:
+#          seqcode: 257
+#        TIC_Averaging:
+#          val: 50
+#
+#      cfg_650:
+#        desc: "650 Hz"
+#        Carbide_PP_Goose:
+#          seqcode: 258
+#        Carbide_PP:
+#          seqcode: 258
+#        TIC_Gate:
+#          seqcode: 258
+#        TIC_Averaging:
+#          val: 50
+#
       cfg_1300:
         desc: "1300 Hz"
-        Carbide_PP_Goose:
+        TIC_Gate:
           seqcode: 259
         Carbide_PP:
-          seqcode: 259
-        TIC_Gate:
           seqcode: 259
         TIC_Averaging:
           val: 50
 
       cfg_2500:
         desc: "2500 Hz"
-        Carbide_PP_Goose:
+        TIC_Gate:
           seqcode: 260
         Carbide_PP:
-          seqcode: 260
-        TIC_Gate:
           seqcode: 260
         TIC_Averaging:
           val: 100
 
       cfg_3250:
         desc: "3250 Hz"
-        Carbide_PP_Goose:
+        TIC_Gate:
           seqcode: 261
         Carbide_PP:
-          seqcode: 261
-        TIC_Gate:
           seqcode: 261
         TIC_Averaging:
           val: 100
 
       cfg_8125:
         desc: "8125 Hz"
-        Carbide_PP_Goose:
+        TIC_Gate:
           seqcode: 272
         Carbide_PP:
-          seqcode: 272
-        TIC_Gate:
           seqcode: 272
         TIC_Averaging:
           val: 500
 
+      cfg_16250:
+        desc: "16250 Hz"
+        TIC_Gate:
+          seqcode: 271
+        Carbide_PP:
+          seqcode: 271
+        TIC_Averaging:
+          val: 1000
+
       cfg_32500:
         desc: "32500 Hz"
-        Carbide_PP_Goose:
+        TIC_Gate:
           seqcode: 262
         Carbide_PP:
           seqcode: 262
-        TIC_Gate:
-          seqcode: 262
         TIC_Averaging:
           val: 2000
+
+      cfg_on_time:
+        desc: "On Time (EC 284)"
+        TIC_Gate:
+          seqcode: 284
+        Carbide_PP:
+          seqcode: 284
+        TIC_Averaging:
+          val: 50
 
     # Allowed goose configs (in TPG seconds) for the given laser
     goose_rate_configs:
       desc: "Goose Rep. Rate"
       cfg_goose_4:
         desc: "4 Hz Goose"
+        TIC_Gate:
+          seqcode: 264
         Carbide_Goose:
           seqcode: 264
         Amphos_Goose:
           seqcode: 264
         Carbide_PP_Goose:
-          seqcode: 264
-        TIC_Gate:
           seqcode: 264
 
       cfg_goose_40:
         desc: "40 Hz Goose"
+        TIC_Gate:
+          seqcode: 265
         Carbide_Goose:
           seqcode: 265
         Amphos_Goose:
           seqcode: 265
         Carbide_PP_Goose:
-          seqcode: 265
-        TIC_Gate:
           seqcode: 265
 
       cfg_goose_50:
         desc: "50 Hz Goose"
+        TIC_Gate:
+          seqcode: 266
         Carbide_Goose:
           seqcode: 266
         Amphos_Goose:
           seqcode: 266
         Carbide_PP_Goose:
-          seqcode: 266
-        TIC_Gate:
           seqcode: 266
 
       cfg_goose_250:
         desc: "250 Hz Goose"
+        TIC_Gate:
+          seqcode: 267
         Carbide_Goose:
           seqcode: 267
         Amphos_Goose:
           seqcode: 267
         Carbide_PP_Goose:
           seqcode: 267
+
+      cfg_goose_625:
+        desc: "625 Hz Goose"
         TIC_Gate:
-          seqcode: 267
+          seqcode: 273
+        Carbide_Goose:
+          seqcode: 273
+        Amphos_Goose:
+          seqcode: 273
+        Carbide_PP_Goose:
+          seqcode: 273
+
+      cfg_goose_off_time:
+        desc: "Off Time (EC 285)"
+        TIC_Gate:
+          seqcode: 285
+        Carbide_Goose:
+          seqcode: 285
+        Amphos_Goose:
+          seqcode: 285
+        Carbide_PP_Goose:
+          seqcode: 285
 
     goose_arrival_configs:
       desc: "Goose Arrival"
@@ -282,7 +312,16 @@ lasers:
         desc: "Goose off"
         Carbide_Base:
           operation: "NOOP"
+          ratemode: "Seq"
+          enable_trg_cmd: "Enabled"
+          enable_ch_cmd: "Enabled"
         Amphos_Base:
           operation: "NOOP"
+          ratemode: "Seq"
+          enable_trg_cmd: "Enabled"
+          enable_ch_cmd: "Enabled"
         Carbide_PP:
           operation: "NOOP"
+          ratemode: "Seq"
+          enable_trg_cmd: "Enabled"
+          enable_ch_cmd: "Enabled"

--- a/opcpa_tpr_config/neh_bay3_config.yaml
+++ b/opcpa_tpr_config/neh_bay3_config.yaml
@@ -92,63 +92,63 @@ lasers:
 #
       cfg_1300:
         desc: "1300 Hz"
-        Carbide_PP:
-          seqcode: 259
         TIC_Gate:
+          seqcode: 259
+        Carbide_PP:
           seqcode: 259
         TIC_Averaging:
           val: 50
 
       cfg_2500:
         desc: "2500 Hz"
-        Carbide_PP:
-          seqcode: 260
         TIC_Gate:
+          seqcode: 260
+        Carbide_PP:
           seqcode: 260
         TIC_Averaging:
           val: 100
 
       cfg_3250:
         desc: "3250 Hz"
-        Carbide_PP:
-          seqcode: 261
         TIC_Gate:
+          seqcode: 261
+        Carbide_PP:
           seqcode: 261
         TIC_Averaging:
           val: 100
 
       cfg_8125:
         desc: "8125 Hz"
-        Carbide_PP:
-          seqcode: 272
         TIC_Gate:
+          seqcode: 272
+        Carbide_PP:
           seqcode: 272
         TIC_Averaging:
           val: 500
 
       cfg_16250:
         desc: "16250 Hz"
-        Carbide_PP:
-          seqcode: 271
         TIC_Gate:
+          seqcode: 271
+        Carbide_PP:
           seqcode: 271
         TIC_Averaging:
           val: 1000
 
       cfg_32500:
         desc: "32500 Hz"
-        Carbide_PP:
-          seqcode: 262
         TIC_Gate:
+          seqcode: 262
+        Carbide_PP:
           seqcode: 262
         TIC_Averaging:
           val: 2000
 
       cfg_on_time:
         desc: "On Time (EC 284)"
-        Carbide_PP:
-          seqcode: 284
         TIC_Gate:
+          seqcode: 284
+        Carbide_PP:
           seqcode: 284
         TIC_Averaging:
           val: 50
@@ -158,68 +158,68 @@ lasers:
       desc: "Goose Rep. Rate"
       cfg_goose_4:
         desc: "4 Hz Goose"
+        TIC_Gate:
+          seqcode: 264
         Carbide_Goose:
           seqcode: 264
         Amphos_Goose:
           seqcode: 264
         Carbide_PP_Goose:
-          seqcode: 264
-        TIC_Gate:
           seqcode: 264
 
       cfg_goose_40:
         desc: "40 Hz Goose"
+        TIC_Gate:
+          seqcode: 265
         Carbide_Goose:
           seqcode: 265
         Amphos_Goose:
           seqcode: 265
         Carbide_PP_Goose:
-          seqcode: 265
-        TIC_Gate:
           seqcode: 265
 
       cfg_goose_50:
         desc: "50 Hz Goose"
+        TIC_Gate:
+          seqcode: 266
         Carbide_Goose:
           seqcode: 266
         Amphos_Goose:
           seqcode: 266
         Carbide_PP_Goose:
-          seqcode: 266
-        TIC_Gate:
           seqcode: 266
 
       cfg_goose_250:
         desc: "250 Hz Goose"
+        TIC_Gate:
+          seqcode: 267
         Carbide_Goose:
           seqcode: 267
         Amphos_Goose:
           seqcode: 267
         Carbide_PP_Goose:
-          seqcode: 267
-        TIC_Gate:
           seqcode: 267
 
       cfg_goose_625:
         desc: "625 Hz Goose"
+        TIC_Gate:
+          seqcode: 273
         Carbide_Goose:
           seqcode: 273
         Amphos_Goose:
           seqcode: 273
         Carbide_PP_Goose:
-          seqcode: 273
-        TIC_Gate:
           seqcode: 273
 
       cfg_goose_off_time:
         desc: "Off Time (EC 285)"
+        TIC_Gate:
+          seqcode: 285
         Carbide_Goose:
           seqcode: 285
         Amphos_Goose:
           seqcode: 285
         Carbide_PP_Goose:
-          seqcode: 285
-        TIC_Gate:
           seqcode: 285
 
     goose_arrival_configs:

--- a/opcpa_tpr_config/neh_bay3_config.yaml
+++ b/opcpa_tpr_config/neh_bay3_config.yaml
@@ -2,7 +2,7 @@
 
 main:
     xpm_pv: "DAQ:NEH:XPM:0:SEQCODES"
-    title: "NEH Laser Hall OPCPA Rep. Rate Configuration"
+    title: "NEH Laser Hall Bay 3 OPCPA Rep. Rate Configuration"
 
 lasers:
   bay_3:


### PR DESCRIPTION
~~Moves the TIC Gate configurations to the top of the configuration, in order to try to prevent TIC issues on rate change. closes #31~~ This didn't actually fix the problem. It didn't break anything either, so I'll leave the signal ordering the way it is. 

Makes the bay 2 configuration identical to the bay 3 configuration. 
