### PR TITLE
Add TIC Gate Goose Trigger

### DIFF
--- a/neh_bay3_db.json
+++ b/neh_bay3_db.json
@@ -143,6 +143,24 @@
         "name": "TIC_Stop",
         "type": "HappiItem"
     },
+    "TIC_Gate_Goose": {
+        "_id": "TIC_Gate_Goose",
+        "active": true,
+        "args": [
+            "LAS:LHN:TPR:01"
+        ],
+        "creation": "Thu Jun  6 07:54:55 2024",
+        "device_class": "pcdsdevices.tpr.TprTrigger",
+        "documentation": "TIC Stop",
+        "kwargs": {
+            "channel": 8,
+            "name": "{{name}}",
+            "timing_mode": 2
+        },
+        "last_edit": "Thu Jun  6 07:54:55 2024",
+        "name": "TIC_Gate_Goose",
+        "type": "HappiItem"
+    },
     "Carbide_Goose_Offset": {
         "_id": "Carbide_Goose_Offset",
         "active": true,
@@ -205,6 +223,22 @@
         },
         "last_edit": "Thu Jun  6 13:54:47 2024",
         "name": "TIC_Gate_Offset",
+        "type": "HappiItem"
+    },
+    "TIC_Gate_Goose_Offset": {
+        "_id": "TIC_Gate_Goose_Offset",
+        "active": true,
+        "args": [
+            "LAS:LHN:LLG2:01:GOOSE:TRIG5_OFFSET"
+        ],
+        "creation": "Thu Jun  6 13:54:47 2024",
+        "device_class": "ophyd.signal.EpicsSignal",
+        "documentation": "TIC Gate Goose Trigger Offset",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Thu Jun  6 13:54:47 2024",
+        "name": "TIC_Gate_Goose_Offset",
         "type": "HappiItem"
     },
     "TIC_Averaging": {

--- a/opcpa_tpr_config/neh_bay2_config.yaml
+++ b/opcpa_tpr_config/neh_bay2_config.yaml
@@ -2,6 +2,7 @@
 
 main:
     xpm_pv: "DAQ:NEH:XPM:0:SEQCODES"
+    meta_pv: "TPG:SYS0:1:DST04"
     title: "NEH Laser Hall Bay 2 OPCPA Rep. Rate Configuration"
 
 lasers:

--- a/opcpa_tpr_config/neh_bay3_config.yaml
+++ b/opcpa_tpr_config/neh_bay3_config.yaml
@@ -164,8 +164,6 @@ lasers:
       desc: "Goose Rep. Rate"
       cfg_goose_4:
         desc: "4 Hz Goose"
-        TIC_Gate:
-          seqcode: 264
         TIC_Gate_Goose:
           seqcode: 264
         Carbide_Goose:
@@ -177,8 +175,6 @@ lasers:
 
       cfg_goose_40:
         desc: "40 Hz Goose"
-        TIC_Gate:
-          seqcode: 265
         TIC_Gate_Goose:
           seqcode: 265
         Carbide_Goose:
@@ -190,8 +186,6 @@ lasers:
 
       cfg_goose_50:
         desc: "50 Hz Goose"
-        TIC_Gate:
-          seqcode: 266
         TIC_Gate_Goose:
           seqcode: 266
         Carbide_Goose:
@@ -203,8 +197,6 @@ lasers:
 
       cfg_goose_250:
         desc: "250 Hz Goose"
-        TIC_Gate:
-          seqcode: 267
         TIC_Gate_Goose:
           seqcode: 267
         Carbide_Goose:
@@ -216,8 +208,6 @@ lasers:
 
       cfg_goose_625:
         desc: "625 Hz Goose"
-        TIC_Gate:
-          seqcode: 273
         TIC_Gate_Goose:
           seqcode: 273
         Carbide_Goose:
@@ -229,8 +219,6 @@ lasers:
 
       cfg_goose_off_time:
         desc: "Off Time (EC 285)"
-        TIC_Gate:
-          seqcode: 285
         TIC_Gate_Goose:
           seqcode: 285
         Carbide_Goose:
@@ -277,9 +265,10 @@ lasers:
           ratemode: "Seq"
           enable_trg_cmd: "Enabled"
           enable_ch_cmd: "Enabled"
+        TIC_Gate:
+          operation: "AND"
         TIC_Gate_Goose:
           ratemode: "Seq"
-          operation: "AND"
           polarity: 0
           width_setpoint: 1000.0
           enable_trg_cmd: "Enabled"
@@ -326,9 +315,10 @@ lasers:
           ratemode: "Seq"
           enable_trg_cmd: "Enabled"
           enable_ch_cmd: "Enabled"
+        TIC_Gate:
+          operation: "AND"
         TIC_Gate_Goose:
           ratemode: "Seq"
-          operation: "AND"
           polarity: 0
           width_setpoint: 1000.0
           enable_trg_cmd: "Enabled"

--- a/opcpa_tpr_config/neh_bay3_config.yaml
+++ b/opcpa_tpr_config/neh_bay3_config.yaml
@@ -2,6 +2,7 @@
 
 main:
     xpm_pv: "DAQ:NEH:XPM:0:SEQCODES"
+    meta_pv: "TPG:SYS0:1:DST04"
     title: "NEH Laser Hall Bay 3 OPCPA Rep. Rate Configuration"
 
 lasers:

--- a/opcpa_tpr_config/neh_bay3_config.yaml
+++ b/opcpa_tpr_config/neh_bay3_config.yaml
@@ -37,6 +37,9 @@ lasers:
       TIC_Gate:
         rbvs: ["name", "eventrate", "ratemode", "seqcode", "width_setpoint", "delay_setpoint", "operation", "enable_ch_cmd"]
         show: True
+      TIC_Gate_Goose:
+        rbvs: ["name", "eventrate", "ratemode", "seqcode", "width_setpoint", "delay_setpoint", "operation", "enable_ch_cmd"]
+        show: True
       Carbide_Goose_Offset:
         rbvs: ["name", "val"]
         show: True
@@ -47,6 +50,9 @@ lasers:
         rbvs: ["name", "val"]
         show: True
       TIC_Gate_Offset:
+        rbvs: ["name", "val"]
+        show: True
+      TIC_Gate_Goose_Offset:
         rbvs: ["name", "val"]
         show: True
       TIC_Averaging:
@@ -160,6 +166,8 @@ lasers:
         desc: "4 Hz Goose"
         TIC_Gate:
           seqcode: 264
+        TIC_Gate_Goose:
+          seqcode: 264
         Carbide_Goose:
           seqcode: 264
         Amphos_Goose:
@@ -170,6 +178,8 @@ lasers:
       cfg_goose_40:
         desc: "40 Hz Goose"
         TIC_Gate:
+          seqcode: 265
+        TIC_Gate_Goose:
           seqcode: 265
         Carbide_Goose:
           seqcode: 265
@@ -182,6 +192,8 @@ lasers:
         desc: "50 Hz Goose"
         TIC_Gate:
           seqcode: 266
+        TIC_Gate_Goose:
+          seqcode: 266
         Carbide_Goose:
           seqcode: 266
         Amphos_Goose:
@@ -192,6 +204,8 @@ lasers:
       cfg_goose_250:
         desc: "250 Hz Goose"
         TIC_Gate:
+          seqcode: 267
+        TIC_Gate_Goose:
           seqcode: 267
         Carbide_Goose:
           seqcode: 267
@@ -204,6 +218,8 @@ lasers:
         desc: "625 Hz Goose"
         TIC_Gate:
           seqcode: 273
+        TIC_Gate_Goose:
+          seqcode: 273
         Carbide_Goose:
           seqcode: 273
         Amphos_Goose:
@@ -214,6 +230,8 @@ lasers:
       cfg_goose_off_time:
         desc: "Off Time (EC 285)"
         TIC_Gate:
+          seqcode: 285
+        TIC_Gate_Goose:
           seqcode: 285
         Carbide_Goose:
           seqcode: 285
@@ -259,6 +277,13 @@ lasers:
           ratemode: "Seq"
           enable_trg_cmd: "Enabled"
           enable_ch_cmd: "Enabled"
+        TIC_Gate_Goose:
+          ratemode: "Seq"
+          operation: "AND"
+          polarity: 0
+          width_setpoint: 1000.0
+          enable_trg_cmd: "Enabled"
+          enable_ch_cmd: "Enabled"
         Carbide_Goose_Offset:
           val: 15.4
         Amphos_Goose_Offset:
@@ -301,6 +326,13 @@ lasers:
           ratemode: "Seq"
           enable_trg_cmd: "Enabled"
           enable_ch_cmd: "Enabled"
+        TIC_Gate_Goose:
+          ratemode: "Seq"
+          operation: "AND"
+          polarity: 0
+          width_setpoint: 1000.0
+          enable_trg_cmd: "Enabled"
+          enable_ch_cmd: "Enabled"
         Carbide_Goose_Offset:
           val: 0.0
         Amphos_Goose_Offset:
@@ -321,6 +353,11 @@ lasers:
           enable_trg_cmd: "Enabled"
           enable_ch_cmd: "Enabled"
         Carbide_PP:
+          operation: "NOOP"
+          ratemode: "Seq"
+          enable_trg_cmd: "Enabled"
+          enable_ch_cmd: "Enabled"
+        TIC_Gate:
           operation: "NOOP"
           ratemode: "Seq"
           enable_trg_cmd: "Enabled"

--- a/opcpa_tpr_config/opcpa_tpr_config.py
+++ b/opcpa_tpr_config/opcpa_tpr_config.py
@@ -54,6 +54,13 @@ class App(Display):
         xpm_pv = self.config["main"]["xpm_pv"]
         self.ui.xpm_label.setText(xpm_pv)
         self.ui.xpm.set_channel(f"pva://{xpm_pv}")
+        meta_pv = self.config["main"]["meta_pv"]
+        self.ui.pattern_name_rbv.set_channel(f"ca://{meta_pv}:NAME")
+        self.ui.rate_rbv.set_channel(f"ca://{meta_pv}:RATE_RBV")
+        self.ui.time_source_rbv.set_channel(f"ca://{meta_pv}:TIME_SRC")
+        self.ui.offset_rbv.set_channel(f"ca://{meta_pv}:OFFSET_RBV")
+        self.ui.time_slot_rbv.set_channel(f"ca://{meta_pv}:TS")
+        self.ui.time_slot_mask_rbv.set_channel(f"ca://{meta_pv}:TSMASK")
 
     def setup_rbvs(self, laser):
         """

--- a/opcpa_tpr_config/opcpa_tpr_config.ui
+++ b/opcpa_tpr_config/opcpa_tpr_config.ui
@@ -85,6 +85,108 @@
       <item>
        <layout class="QVBoxLayout" name="xpm_vlayout">
         <item>
+         <widget class="QLabel" name="label">
+          <property name="font">
+           <font>
+            <weight>75</weight>
+            <bold>true</bold>
+            <underline>false</underline>
+           </font>
+          </property>
+          <property name="text">
+           <string>SC Pattern Metadata</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <layout class="QGridLayout" name="gridLayout">
+          <item row="0" column="1">
+           <widget class="PyDMLabel" name="pattern_name_rbv">
+            <property name="toolTip">
+             <string/>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="PyDMLabel" name="time_source_rbv">
+            <property name="toolTip">
+             <string/>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="offset_rbv_label">
+            <property name="text">
+             <string>Offset RBV</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="0">
+           <widget class="QLabel" name="time_slot_label">
+            <property name="text">
+             <string>Time Slot</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="0">
+           <widget class="QLabel" name="name_label">
+            <property name="text">
+             <string>Name</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="1">
+           <widget class="PyDMLabel" name="time_slot_rbv">
+            <property name="toolTip">
+             <string/>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="time_source_label">
+            <property name="text">
+             <string>Time Source</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="rate_rbv_label">
+            <property name="text">
+             <string>Rate RBV</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="PyDMLabel" name="rate_rbv">
+            <property name="toolTip">
+             <string/>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="PyDMLabel" name="offset_rbv">
+            <property name="toolTip">
+             <string/>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="0">
+           <widget class="QLabel" name="time_slot_mask_label">
+            <property name="text">
+             <string>Time Slot Mask</string>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="1">
+           <widget class="PyDMLabel" name="time_slot_mask_rbv">
+            <property name="toolTip">
+             <string/>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item>
          <widget class="PyDMLabel" name="xpm_label">
           <property name="font">
            <font>
@@ -100,7 +202,7 @@
         <item>
          <widget class="PyDMNTTable" name="xpm">
           <property name="sizePolicy">
-           <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+           <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>
@@ -109,6 +211,12 @@
            <size>
             <width>100</width>
             <height>0</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>470</width>
+            <height>16777215</height>
            </size>
           </property>
           <property name="toolTip">


### PR DESCRIPTION
Adds support for controlling the TIC gate goose trigger.

Ride-along update for SC timing metadata PVs. Adds support for viewing them, but doesn't do anything with them regarding XPM programming (yet). 

closes #35 
closes #34 

SC Timing PVs on screen: 
![image](https://github.com/user-attachments/assets/3eecb783-6735-4d55-a731-18ad60151108)
