### PR TITLE
Updates on v2.0.0 

### DIFF
--- a/opcpa_tpr_config/neh_bay2_config.yaml
+++ b/opcpa_tpr_config/neh_bay2_config.yaml
@@ -3,6 +3,7 @@
 main:
     xpm_pv: "DAQ:NEH:XPM:0"
     meta_pv: "TPG:SYS0:1:DST04"
+    notepad_pv: "LAS:NEH:BAY2:PVPAD"
     engine1: "4"
     engine2: "5"
     title: "NEH Laser Hall Bay 2 OPCPA Rep. Rate Configuration"

--- a/opcpa_tpr_config/neh_bay3_config.yaml
+++ b/opcpa_tpr_config/neh_bay3_config.yaml
@@ -3,6 +3,7 @@
 main:
     xpm_pv: "DAQ:NEH:XPM:0"
     meta_pv: "TPG:SYS0:1:DST04"
+    notepad_pv: "LAS:NEH:BAY3:PVPAD"
     engine1: "6"
     engine2: "7"
     title: "NEH Laser Hall Bay 3 OPCPA Rep. Rate Configuration"

--- a/opcpa_tpr_config/rep_rate_config.ui
+++ b/opcpa_tpr_config/rep_rate_config.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>279</width>
-    <height>269</height>
+    <height>381</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -139,6 +139,67 @@
     </layout>
    </item>
    <item>
+    <layout class="QVBoxLayout" name="sc_bucket_layout">
+     <item>
+      <layout class="QHBoxLayout" name="sc_bucket_ctl_layout">
+       <item>
+        <widget class="QLabel" name="sc_start_bucket_control_label">
+         <property name="text">
+          <string>SC Start Bucket Control</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QComboBox" name="sc_bucket_control_box"/>
+       </item>
+      </layout>
+     </item>
+     <item>
+      <layout class="QHBoxLayout" name="sc_bucket_set_layout">
+       <item>
+        <widget class="QLabel" name="sc_start_bucket_label">
+         <property name="text">
+          <string>SC Start Bucket</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLineEdit" name="sc_bucket_edit">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="inputMask">
+          <string>9</string>
+         </property>
+         <property name="text">
+          <string>0</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="PyDMLabel" name="sc_bucket_rbv">
+         <property name="toolTip">
+          <string/>
+         </property>
+         <property name="text">
+          <string>##</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+    </layout>
+   </item>
+   <item>
     <layout class="QHBoxLayout" name="total_rate_layout">
      <item>
       <widget class="QLabel" name="total_rate_label">
@@ -199,6 +260,33 @@
       <string>TextLabel</string>
      </property>
     </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="timestamp_layout">
+     <item>
+      <widget class="QLabel" name="timestamp_label">
+       <property name="text">
+        <string>Last Update:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="PyDMLabel" name="timestamp_rbv">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
    <item>
     <spacer name="verticalSpacer">

--- a/opcpa_tpr_config/rep_rate_config.ui
+++ b/opcpa_tpr_config/rep_rate_config.ui
@@ -181,9 +181,15 @@
     </layout>
    </item>
    <item>
-    <widget class="QPushButton" name="apply_button">
+    <widget class="PyDMPushButton" name="apply_button">
+     <property name="toolTip">
+      <string/>
+     </property>
      <property name="text">
       <string>Apply Configuration</string>
+     </property>
+     <property name="showConfirmDialog" stdset="0">
+      <bool>true</bool>
      </property>
     </widget>
    </item>
@@ -207,6 +213,11 @@
    <class>PyDMLabel</class>
    <extends>QLabel</extends>
    <header>pydm.widgets.label</header>
+  </customwidget>
+  <customwidget>
+   <class>PyDMPushButton</class>
+   <extends>QPushButton</extends>
+   <header>pydm.widgets.pushbutton</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/opcpa_tpr_config/rep_rate_config.ui
+++ b/opcpa_tpr_config/rep_rate_config.ui
@@ -273,7 +273,7 @@
      <item>
       <widget class="PyDMLabel" name="timestamp_rbv">
        <property name="sizePolicy">
-        <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
          <horstretch>0</horstretch>
          <verstretch>0</verstretch>
         </sizepolicy>
@@ -282,7 +282,7 @@
         <string/>
        </property>
        <property name="alignment">
-        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
        </property>
       </widget>
      </item>

--- a/opcpa_tpr_config/rep_rate_config.ui
+++ b/opcpa_tpr_config/rep_rate_config.ui
@@ -23,7 +23,7 @@
       </font>
      </property>
      <property name="text">
-      <string>Rep. Rate Control</string>
+      <string>Laser Control</string>
      </property>
     </widget>
    </item>
@@ -145,7 +145,7 @@
        <item>
         <widget class="QLabel" name="sc_start_bucket_control_label">
          <property name="text">
-          <string>SC Start Bucket Control</string>
+          <string>Start Bucket Control</string>
          </property>
         </widget>
        </item>
@@ -159,7 +159,7 @@
        <item>
         <widget class="QLabel" name="sc_start_bucket_label">
          <property name="text">
-          <string>SC Start Bucket</string>
+          <string>Start Bucket</string>
          </property>
         </widget>
        </item>
@@ -179,6 +179,13 @@
          </property>
          <property name="alignment">
           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="sc_bucket_rbv_label">
+         <property name="text">
+          <string>RBV: </string>
          </property>
         </widget>
        </item>

--- a/opcpa_tpr_config/rep_rate_config.ui
+++ b/opcpa_tpr_config/rep_rate_config.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>228</width>
-    <height>238</height>
+    <width>279</width>
+    <height>269</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -41,8 +41,15 @@
      <property name="bottomMargin">
       <number>6</number>
      </property>
-     <item row="1" column="2">
-      <widget class="PyDMLabel" name="on_time_rate_rbv">
+     <item row="1" column="0">
+      <widget class="QLabel" name="on_time_label">
+       <property name="text">
+        <string>On Time Shots</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="PyDMLabel" name="on_time_ec_rbv">
        <property name="toolTip">
         <string/>
        </property>
@@ -61,23 +68,6 @@
        </property>
       </widget>
      </item>
-     <item row="1" column="1">
-      <widget class="PyDMLabel" name="on_time_ec_rbv">
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="1">
-      <widget class="QLabel" name="ec_label">
-       <property name="text">
-        <string>Event Code</string>
-       </property>
-      </widget>
-     </item>
      <item row="2" column="2">
       <widget class="PyDMLabel" name="off_time_rate_rbv">
        <property name="toolTip">
@@ -85,13 +75,6 @@
        </property>
        <property name="alignment">
         <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="0">
-      <widget class="QLabel" name="on_time_label">
-       <property name="text">
-        <string>On Time</string>
        </property>
       </widget>
      </item>
@@ -105,7 +88,51 @@
      <item row="2" column="0">
       <widget class="QLabel" name="off_time_label">
        <property name="text">
-        <string>Off Time</string>
+        <string>Goose Shots</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QLabel" name="ec_label">
+       <property name="text">
+        <string>Event Code</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="2">
+      <widget class="PyDMLabel" name="on_time_rate_rbv">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="0">
+      <widget class="QLabel" name="all_shots_label">
+       <property name="text">
+        <string>All Laser Shots</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="1">
+      <widget class="PyDMLabel" name="all_shots_ec_rbv">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="2">
+      <widget class="PyDMLabel" name="all_shots_rate_rbv">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
        </property>
       </widget>
      </item>

--- a/opcpa_tpr_config/rep_rate_config.ui
+++ b/opcpa_tpr_config/rep_rate_config.ui
@@ -194,6 +194,13 @@
     </widget>
    </item>
    <item>
+    <widget class="QLabel" name="status_label">
+     <property name="text">
+      <string>TextLabel</string>
+     </property>
+    </widget>
+   </item>
+   <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>

--- a/opcpa_tpr_config/sc_metadata.ui
+++ b/opcpa_tpr_config/sc_metadata.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>231</width>
-    <height>185</height>
+    <height>191</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -24,7 +24,7 @@
       </font>
      </property>
      <property name="text">
-      <string>SC Pattern Metadata</string>
+      <string>X-ray Status</string>
      </property>
     </widget>
    </item>

--- a/opcpa_tpr_config/widgets.py
+++ b/opcpa_tpr_config/widgets.py
@@ -194,7 +194,7 @@ class LaserConfigDisplay(Display):
         # "Notepad" PVs
         notepad_pv = self._config['main']['notepad_pv']
         self.sc_bucket_rbv.set_channel(f"ca://{notepad_pv}:SC_BUCKET")
-        self.timestamp_rbv.set_channel(f"ca://{notepad_pv}:TIMESTAMP")
+        self.timestamp_rbv.set_channel(f"ca://{notepad_pv}:SC_TIMESTAMP")
 
         if self._debug:
             print(f"Engine 1: {self._engine1}")
@@ -606,7 +606,7 @@ class UserConfigDisplay(Display):
         """
         Write the current time into the timestamp PV for this system.
         """
-        pv = self._config['main']['notepad_pv'] + ':TIMESTAMP'
+        pv = self._config['main']['notepad_pv'] + ':SC_TIMESTAMP'
         sig = EpicsSignal(pv)
         t = time.asctime()
         sig.put(t)

--- a/opcpa_tpr_config/widgets.py
+++ b/opcpa_tpr_config/widgets.py
@@ -101,6 +101,7 @@ class LaserConfigDisplay(Display):
     goose_arrival_label: QtWidgets.QLabel
 
     apply_button: pydm_widgets.PyDMPushButton
+    status_label: QtWidgets.QLabel
 
     def __init__(
         self,
@@ -129,6 +130,8 @@ class LaserConfigDisplay(Display):
             cfg_keys = self._config.keys()
             print(f"Configuration sections: {cfg_keys}")
             print(self._config)
+
+        self.status_label.setText("Status: Idle")
 
         self.update_pvs()
 
@@ -690,8 +693,10 @@ class UserConfigDisplay(Display):
         """
         Apply the requested configuration to the system.
         """
+        self.laser_config_widget.status_label.setText("Status: Configuring...")
         self.set_tic_enable(False)
         self.apply_base_rates()
         self.apply_laser_rates()
         self.apply_device_config()
         self.set_tic_enable(True)
+        self.laser_config_widget.status_label.setText("Status: Config Done")

--- a/opcpa_tpr_config/widgets.py
+++ b/opcpa_tpr_config/widgets.py
@@ -756,11 +756,14 @@ class UserConfigDisplay(Display):
                 instance = device.get()
                 instance.configure(conf)
 
+    def update_status(self, status):
+        self.laser_config_widget.status_label.setText(status)
+
     def apply_config(self):
         """
         Apply the requested configuration to the system.
         """
-        self.laser_config_widget.status_label.setText("Status: Configuring...")
+        self.update_status("Status: Configuring...")
         self.set_tic_enable(False)
         self.apply_base_rates()
         self.apply_laser_rates()
@@ -768,4 +771,4 @@ class UserConfigDisplay(Display):
         self.set_tic_enable(True)
         self.write_offset(self.offset)
         self.write_timestamp()
-        self.laser_config_widget.status_label.setText("Status: Config Done")
+        self.update_status("Status: Config Done")

--- a/opcpa_tpr_config/widgets.py
+++ b/opcpa_tpr_config/widgets.py
@@ -296,7 +296,7 @@ class LaserConfigDisplay(Display):
 
     @property
     def manual_bucket(self):
-        return int(self.sc_bucket_edit.text)
+        return int(self.sc_bucket_edit.text())
 
 
 class ExpertDisplay(Display):

--- a/opcpa_tpr_config/widgets.py
+++ b/opcpa_tpr_config/widgets.py
@@ -195,7 +195,12 @@ class LaserConfigDisplay(Display):
     def update_base_rates(self):
         if self._base_rates is not None:
             for rate in self._base_rates:
-                self.total_rate_box.addItem(str(rate))
+                # Restrict allowed rates to > 1kHz, but keep all rates in
+                # self._base_rates for allowed goose rate calculation
+                # TODO: The calculation of goose rates could probably be
+                # decoupled from the base rate array.
+                if rate >= 1000:
+                    self.total_rate_box.addItem(str(rate))
             if self._debug:
                 print(f"Allowed base rates: {self._base_rates}")
 

--- a/opcpa_tpr_config/widgets.py
+++ b/opcpa_tpr_config/widgets.py
@@ -90,6 +90,8 @@ class LaserConfigDisplay(Display):
     on_time_rate_rbv: pydm_widgets.PyDMLabel
     off_time_ec_rbv: pydm_widgets.PyDMLabel
     off_time_rate_rbv: pydm_widgets.PyDMLabel
+    all_shots_ec_rbv: pydm_widgets.PyDMLabel
+    all_shots_rate_rbv: pydm_widgets.PyDMLabel
 
     total_rate_box: QtWidgets.QComboBox
     total_rate_label: QtWidgets.QLabel
@@ -153,16 +155,22 @@ class LaserConfigDisplay(Display):
         xpm_pv = self._config['main']['xpm_pv']
         on_time_idx = self._engine1 * 4
         off_time_idx = (self._engine1 * 4) + 1
+        all_shots_idx = (self._engine1 * 4) + 2
         self._on_time = 256 + on_time_idx
         self._off_time = 256 + off_time_idx
+        self._all_shots = 256 + all_shots_idx
 
         self.on_time_ec_rbv.setText(str(self._on_time))
         self.off_time_ec_rbv.setText(str(self._off_time))
+        self.all_shots_ec_rbv.setText(str(self._all_shots))
         self.on_time_rate_rbv.set_channel(
             f"pva://{xpm_pv}:SEQCODES/Rate/{on_time_idx}"
         )
         self.off_time_rate_rbv.set_channel(
             f"pva://{xpm_pv}:SEQCODES/Rate/{off_time_idx}"
+        )
+        self.all_shots_rate_rbv.set_channel(
+            f"pva://{xpm_pv}:SEQCODES/Rate/{all_shots_idx}"
         )
 
         if self._debug:
@@ -602,8 +610,8 @@ class UserConfigDisplay(Display):
         instrset = make_sequence(base_div, goose_div, offset, self._debug)
 
         bay = self._config['main']['bay']
-        seqdesc = {0: f"{bay} On time", 1: f"{bay} Off time",
-                   2: f"{bay} total rate", 3: ""}
+        seqdesc = {0: f"{bay} On time shots", 1: f"{bay} Goose shots",
+                   2: f"{bay} All laser shots", 3: ""}
 
         self.write_xpm_config(seqdesc, instrset, self._LasSeq, self._engine1)
 

--- a/opcpa_tpr_config/widgets.py
+++ b/opcpa_tpr_config/widgets.py
@@ -100,7 +100,7 @@ class LaserConfigDisplay(Display):
     goose_arrival_box: QtWidgets.QComboBox
     goose_arrival_label: QtWidgets.QLabel
 
-    apply_button: QtWidgets.QPushButton
+    apply_button: pydm_widgets.PyDMPushButton
 
     def __init__(
         self,

--- a/opcpa_tpr_config/widgets.py
+++ b/opcpa_tpr_config/widgets.py
@@ -140,6 +140,7 @@ class LaserConfigDisplay(Display):
             print(self._config)
 
         self.status_label.setText("Status: Idle")
+        self.status_label.setVisible(False)
 
         self.update_pvs()
 

--- a/opcpa_tpr_config/widgets.py
+++ b/opcpa_tpr_config/widgets.py
@@ -140,6 +140,8 @@ class LaserConfigDisplay(Display):
             print(self._config)
 
         self.status_label.setText("Status: Idle")
+        # Hiding this because the status doesn't work well without threading
+        # the configuration method. Will remove once that's done in a later PR
         self.status_label.setVisible(False)
 
         self.update_pvs()

--- a/opcpa_tpr_config/xpm_prog.py
+++ b/opcpa_tpr_config/xpm_prog.py
@@ -25,7 +25,7 @@ def make_base_rates(laser_factors):
             q = np.prod(np.array(c))
             f.add(q)
 
-    return sorted(list(f), reverse=True)
+    return sorted(list(f))
 
 
 def allowed_goose_rates(base_rate, rate_list):


### PR DESCRIPTION
### Description
This PR addresses a bunch of smaller issues that were raised after the first weekend of use of the new system. At a high level, these are:
- Provide readbacks to indicate the most recently programmed SC bucket offset (typically 0 or 7, as dictated by the machine configuration)
- Provide a way to manually set the programmed bucket offset. This is for applying a particular bucket offset when the machine is _not_ in that configuration, for example off-shift timing setup. 
- Update the names of the various laser codes to something more meaningful to the laser scientists
- Provide protection against programming unwanted rates by ~~adding a confirmation dialog and~~ making the "safer" rates show up first in the list. 
- Provide indicators showing that programming has occurred and is complete, such as ~~including a "status" indicator and~~ an indicator for the timestamp of the most recent successful configuration. 

### Motivation
The various feature requests/changes have been documented in GH issues, listed below. 

Closes #44 
~~Closes 46~~  Despite checking the show confirmation dialog property, this does not work. This will need to be investigated more closely resolved in a later PR. 
~~Closes 47~~  This status indicator does not work properly because the text doesn't update until the configuration method completes. This should be functional after threading the configuration method (#48)
Closes #49 
Closes #50 
Closes #51 
Closes #53 

### Screenshots
![image](https://github.com/user-attachments/assets/b4113b4a-cbef-4faf-ba40-4ef87aa207ef)


