### PR TITLE
ENH: update calc_tic_averaging to use two distinct sample sizes

### DIFF
--- a/opcpa_tpr_config/widgets.py
+++ b/opcpa_tpr_config/widgets.py
@@ -652,18 +652,8 @@ class UserConfigDisplay(Display):
         logarithm.
         """
         rate = int(total_rate)
-        if rate < 1000:
-            return 50
-        elif rate < 2000:
-            return 100
-        elif rate < 4000:
-            return 200
-        elif rate < 10000:
-            return 500
-        elif rate < 20000:
-            return 1000
-        else:  # The rep rate can't go over 33kHz so we stop here
-            return 2000
+        sample_size = 200 if rate > 2000 else 100
+        return sample_size
 
     def apply_laser_rates(self):
         """


### PR DESCRIPTION
Pretty small change here to match the `sample_size` determination in https://jira.slac.stanford.edu/browse/TSS-441.

Tested on Zone 2 with Ryan and details are in that JIRA ticket. They'd like to get this merged and deployed before TMO's beam time at 2 PM today, otherwise it can wait until the next week for Zone 3.