### PR TITLE
Rep Rate Config Indicator light and Conda Env Update

### DIFF
--- a/launcher.sh
+++ b/launcher.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 
 # Uncomment and set to the latest version to freeze dependency
-#export PCDS_CONDA_VER=5.8.0
+export PCDS_CONDA_VER=6.0.1
 #export PCDS_CONDA_VER=dev
 
 source /cds/group/pcds/pyps/conda/pcds_conda
-export PYTHONPATH=/cds/group/pcds/pyps/apps/dev/pythonpath:$PYTHONPATH
-export PYTHONPATH=/cds/home/t/tjohnson/trunk/forks/pydm:$PYTHONPATH
+# export PYTHONPATH=/cds/group/pcds/pyps/apps/dev/pythonpath:$PYTHONPATH
+# export PYTHONPATH=/cds/home/t/tjohnson/trunk/forks/pydm:$PYTHONPATH
 #export PYTHONPATH=/cds/home/opr/tmoopr/git/lcls2_051024/psdaq:$PYTHONPATH
 export PYTHONPATH=/cds/home/opr/rixopr/git/lcls2_101824/psdaq:$PYTHONPATH
 

--- a/launcher.sh
+++ b/launcher.sh
@@ -1,13 +1,8 @@
 #!/bin/bash
 
-# Uncomment and set to the latest version to freeze dependency
 export PCDS_CONDA_VER=6.0.1
-#export PCDS_CONDA_VER=dev
 
 source /cds/group/pcds/pyps/conda/pcds_conda
-# export PYTHONPATH=/cds/group/pcds/pyps/apps/dev/pythonpath:$PYTHONPATH
-# export PYTHONPATH=/cds/home/t/tjohnson/trunk/forks/pydm:$PYTHONPATH
-#export PYTHONPATH=/cds/home/opr/tmoopr/git/lcls2_051024/psdaq:$PYTHONPATH
 export PYTHONPATH=/cds/home/opr/rixopr/git/lcls2_101824/psdaq:$PYTHONPATH
 
 if [[ $# -ne 1 ]]; then

--- a/opcpa_tpr_config/rep_rate_config.ui
+++ b/opcpa_tpr_config/rep_rate_config.ui
@@ -202,6 +202,37 @@
          </property>
         </widget>
        </item>
+       <item>
+        <widget class="PyDMByteIndicator" name="sc_bucket_is_synced">
+         <property name="toolTip">
+          <string/>
+         </property>
+         <property name="channel" stdset="0">
+          <string/>
+         </property>
+         <property name="showLabels" stdset="0">
+          <bool>false</bool>
+         </property>
+         <property name="labels" stdset="0">
+          <stringlist notr="true">
+           <string>Is Synced</string>
+          </stringlist>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="PyDMLabel" name="sc_bucket_is_synced_label">
+         <property name="toolTip">
+          <string/>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+         <property name="rules" stdset="0">
+          <string>[]</string>
+         </property>
+        </widget>
+       </item>
       </layout>
      </item>
     </layout>
@@ -295,7 +326,7 @@
      </item>
     </layout>
    </item>
-   <item>
+<item>
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -315,6 +346,11 @@
    <class>PyDMLabel</class>
    <extends>QLabel</extends>
    <header>pydm.widgets.label</header>
+  </customwidget>
+  <customwidget>
+   <class>PyDMByteIndicator</class>
+   <extends>QWidget</extends>
+   <header>pydm.widgets.byte</header>
   </customwidget>
   <customwidget>
    <class>PyDMPushButton</class>

--- a/opcpa_tpr_config/widgets.py
+++ b/opcpa_tpr_config/widgets.py
@@ -98,6 +98,8 @@ class LaserConfigDisplay(Display):
     sc_bucket_control_box: QtWidgets.QComboBox
     sc_bucket_edit: QtWidgets.QLineEdit
     sc_bucket_rbv: pydm_widgets.PyDMLabel
+    sc_bucket_is_synced: pydm_widgets.PyDMByteIndicator
+    sc_bucket_is_synced_label: pydm_widgets.PyDMLabel
 
     timestamp_rbv: pydm_widgets.PyDMLabel
 
@@ -198,6 +200,31 @@ class LaserConfigDisplay(Display):
         notepad_pv = self._config['main']['notepad_pv']
         self.sc_bucket_rbv.set_channel(f"ca://{notepad_pv}:SC_BUCKET")
         self.timestamp_rbv.set_channel(f"ca://{notepad_pv}:SC_TIMESTAMP")
+
+        # start buckets synced indicator
+        sc_base = self._config['main']['meta_pv']
+        self.sc_bucket_is_synced.set_channel(
+            f"calc://compare_buckets?"
+            f"laser_bucket=ca://{notepad_pv}:SC_BUCKET&"
+            f"xray_bucket=ca://{sc_base}:OFFSET_RBV&"
+            f"expr=1 if laser_bucket==xray_bucket else 0"
+        )
+        self.sc_bucket_is_synced_label.rules = '''[
+        {
+            "name": "bool_label",
+            "property": "Text",
+            "initial_value": "",
+            "expression": "{0: \\"Not-Synced\\" , 1: \\"    Synced\\"}[ch[0]]",
+            "channels": [
+            {
+                "channel": "calc://compare_buckets",
+                "trigger": true,
+                "use_enum": false
+            }
+            ],
+            "notes": ""
+        }
+        ]'''
 
         if self._debug:
             print(f"Engine 1: {self._engine1}")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- Adds an indicator light that shows if start buckets are synced.
-  Updates conda environment
-  Removed PyDM hotfix/fork as bug fixed upstream

## Motivation and Context

[ECS-7389](https://jira.slac.stanford.edu/browse/ECS-7389)
Closes #54

## How Has This Been Tested?

Test Plan:
1.  Apply 3 different base rates, one with a goose trigger, confirming that the TPR in the laser locker sees the new rates.
2.  Apply and remove a start bucket offset that is different from xrays and confirm sync light works as expected.

 Tested and confirmed working on 8/19/2025 at 5:30pm from las-console and remotely

## Where Has This Been Documented?
This PR. 


Screenshots:
<img width="913" height="1533" alt="image" src="https://github.com/user-attachments/assets/e1bb1503-9118-4969-aef2-d6ca03479931" />
<img width="855" height="634" alt="image" src="https://github.com/user-attachments/assets/0f7f1ebb-e86b-419d-ad7c-7eaf0aa11784" />


## Pre-merge checklist
- [X ] Code works interactively
- [X ] Code contains descriptive docstrings, including context and API
