### PR TITLE
WIP: Change from 32.5kHz base rate to 70kHz base rate

### DIFF
--- a/opcpa_tpr_config/widgets.py
+++ b/opcpa_tpr_config/widgets.py
@@ -12,8 +12,8 @@ from psdaq.seq.seqprogram import SeqUser
 from pydm import Display
 from pydm import widgets as pydm_widgets
 from qtpy import QtWidgets
-from xpm_prog import (allowed_goose_rates, carbide_factors, make_base_rates,
-                      make_base_sequence, make_sequence)
+from xpm_prog import (allowed_goose_rates, carbide_70k_factors,
+                      make_70k_base_sequence, make_base_rates, make_sequence)
 
 logger = logging.getLogger(__name__)
 
@@ -148,7 +148,7 @@ class LaserConfigDisplay(Display):
 
         self.update_pvs()
 
-        self._base_rates = make_base_rates(carbide_factors)
+        self._base_rates = make_base_rates(carbide_70k_factors)
 
         self.update_base_rates()
 
@@ -719,11 +719,11 @@ class UserConfigDisplay(Display):
             print("Applying base rates")
             print(f"Offset: {self.offset}")
 
-        instrset = make_base_sequence(self.offset)
+        instrset = make_70k_base_sequence(self.offset)
 
         bay = self._config['main']['bay']
-        seqdesc = {0: f"{bay} 910kHz", 1: f"{bay} 32.5kHz", 2: f"{bay} 100Hz",
-                   3: f"{bay} 5Hz"}
+        seqdesc = {0: f"{bay} 910kHz", 1: f"{bay} 70kHz", 2: f"{bay} 112Hz",
+                   3: f"{bay} 7Hz"}
 
         self.write_xpm_config(seqdesc, instrset, self._BaseSeq, self._engine2)
 

--- a/opcpa_tpr_config/xpm_prog.py
+++ b/opcpa_tpr_config/xpm_prog.py
@@ -9,6 +9,7 @@ from psdaq.seq.seqprogram import SeqUser
 
 all_factors = [1, 2, 2, 2, 2, 5, 5, 5, 5, 7, 13]  # 910,000
 carbide_factors = [1, 2, 2, 5, 5, 5, 5, 13]  # 32,500 (remove 2, 2, 7, add 1)
+carbide_70k_factors = [1, 2, 2, 5, 5, 5, 5]  # 70,000 (remove 13, add 1)
 
 
 def make_base_factors(base_div, factors):

--- a/opcpa_tpr_config/xpm_prog.py
+++ b/opcpa_tpr_config/xpm_prog.py
@@ -159,6 +159,53 @@ def make_base_sequence(offset=None):
     return instrset
 
 
+def make_70k_base_sequence(offset=None):
+    """
+    Setup standard sequence of full rate, 70000, 112, and 7 Hz codes.
+    """
+    # Do some setup
+    instrset = []
+
+    # Insert bucket offset if it is present
+    if offset is not None and offset != 0:
+        instrset.append(FixedRateSync(marker="910kH", occ=offset))
+
+    b0 = len(instrset)
+    instrset.append(ControlRequest([0, 1, 2, 3]))
+    instrset.append(FixedRateSync(marker="910kH", occ=1))
+    b1 = len(instrset)
+    instrset.append(ControlRequest([0]))
+    instrset.append(FixedRateSync(marker="910kH", occ=1))
+    instrset.append(Branch.conditional(line=b1, counter=0, value=11))
+    b2 = len(instrset)
+    instrset.append(ControlRequest([0, 1]))
+    instrset.append(FixedRateSync(marker="910kH", occ=1))
+    b3 = len(instrset)
+    instrset.append(ControlRequest([0]))
+    instrset.append(FixedRateSync(marker="910kH", occ=1))
+    instrset.append(Branch.conditional(line=b3, counter=0, value=11))
+    instrset.append(Branch.conditional(line=b2, counter=1, value=623))
+    b4 = len(instrset)
+    instrset.append(ControlRequest([0, 1, 2]))
+    instrset.append(FixedRateSync(marker="910kH", occ=1))
+    b5 = len(instrset)
+    instrset.append(ControlRequest([0]))
+    instrset.append(FixedRateSync(marker="910kH", occ=1))
+    instrset.append(Branch.conditional(line=b5, counter=0, value=11))
+    b6 = len(instrset)
+    instrset.append(ControlRequest([0, 1]))
+    instrset.append(FixedRateSync(marker="910kH", occ=1))
+    b7 = len(instrset)
+    instrset.append(ControlRequest([0]))
+    instrset.append(FixedRateSync(marker="910kH", occ=1))
+    instrset.append(Branch.conditional(line=b7, counter=0, value=11))
+    instrset.append(Branch.conditional(line=b6, counter=1, value=623))
+    instrset.append(Branch.conditional(line=b4, counter=2, value=14))
+    instrset.append(Branch.unconditional(line=b0))
+
+    return instrset
+
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
 

--- a/opcpa_tpr_config/xpm_prog.py
+++ b/opcpa_tpr_config/xpm_prog.py
@@ -1,4 +1,5 @@
 import argparse
+import copy
 import itertools
 
 import numpy as np
@@ -6,8 +7,35 @@ from psdaq.cas.pvedit import Pv
 from psdaq.seq.seq import Branch, ControlRequest, FixedRateSync
 from psdaq.seq.seqprogram import SeqUser
 
-factors = [2, 2, 2, 2, 5, 5, 5, 5, 7, 13]  # 910,000
+all_factors = [1, 2, 2, 2, 2, 5, 5, 5, 5, 7, 13]  # 910,000
 carbide_factors = [1, 2, 2, 5, 5, 5, 5, 13]  # 32,500 (remove 2, 2, 7, add 1)
+
+
+def make_base_factors(base_div, factors):
+    """
+    Generate a list of allowed divisors from a base rate divisor and a list of
+    allowed factors.
+    """
+    # Our factors list is a variable we may want to re-use elsewhere
+    f = copy.deepcopy(factors)
+
+    # Make sure we're not using an unsupported divisor; must be an integer
+    # multiple of our available dividers.
+    max_rate = int(np.prod(f))
+    if max_rate % base_div != 0:
+        raise ValueError("Laser rate not evenly divisble by base divider!")
+
+    for factor in f:
+        # Everything is divisible by 1, and we want to keep 1 in the list
+        if factor == 1:
+            continue
+        if base_div % factor == 0:
+            base_div /= factor
+            f.remove(factor)
+            continue
+        elif base_div == 1:
+            break
+    return f
 
 
 def make_base_rates(laser_factors):

--- a/opcpa_tpr_config/xpm_prog.py
+++ b/opcpa_tpr_config/xpm_prog.py
@@ -40,7 +40,7 @@ def make_base_factors(base_div, factors):
 
 def make_base_rates(laser_factors):
     """
-    Generate a dictionary of factors --> rates (TPG second)
+    Generate a list of rates (TPG second) based on allowd factors
     """
     iters = [
         itertools.combinations(
@@ -58,7 +58,7 @@ def make_base_rates(laser_factors):
 
 def allowed_goose_rates(base_rate, rate_list):
     """
-    Return a dict of allowed goose rates, based on the base rate of the laser
+    Return a list of allowed goose rates, based on the base rate of the laser
     and a dictionary of allowed base rates created using make_base_rates().
     """
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Modifies the code to produce a 70kHz base rate sequence, with updated diagnostic codes. Also adds a function (`make_base_factors`) that was a start towards generalizing the generation of allowed laser factors and allowed rates. 

## Motivation and Context
TMO has an experiment in November that is geared towards demonstrating a higher rate experiment than previously attempted. Originally intended to demonstrate "100kHz" operation (really ~92.8kHz), the plans have since changed to be a 70kHz experiment. 

I originally started out trying to generalize the code so that this is easier to do in the future. The idea is that we should be able to specify a single divider (or rate) that is used to calculate the allowed sub-rates and generate an appropriate sequence for the base rate and compatible diagnostic codes. I started in this direction with `make_base_factors` but found that the math was even harder than I thought. I have some ideas about how to do this, but don't have time to pull it over the finish line. It's not clear if switching base rates will be common or not in the future.  

Given that this is a one-off experiment at this rate (all other experiments until the long down will be our normal setup, and we'll be at 120Hz during the SC down) I decided to do this the quick 'n' dirty way. I'm not even sure that I'll merge any of this, except maybe the commit with `make_base_factors`. I thought I still ought to put up a PR for informational purposes to keep others in the loop and see if anyone spots any issues.

https://jira.slac.stanford.edu/browse/ECS-8250

## How Has This Been Tested?
WIP. Testing planned for next week during the PAMM. 

## Where Has This Been Documented?
This PR. 

## Screenshots (if appropriate):
I've simulated the 70kHz pattern and everything appears to line up as I expect. 

910,000 / 13 = 70kHz

910,000 / 8125 = 112 Hz

910,000 / 130,000 = 7 Hz

<img width="1919" height="933" alt="image" src="https://github.com/user-attachments/assets/6b154744-8dd8-468a-bfee-e35625e80da1" />

<img width="1919" height="931" alt="image" src="https://github.com/user-attachments/assets/14124828-6408-4908-855a-9f222e8d0f33" />

<img width="1919" height="932" alt="image" src="https://github.com/user-attachments/assets/1e407908-ed1f-426c-b674-9b860e6afd5a" />

<img width="1916" height="931" alt="image" src="https://github.com/user-attachments/assets/52466d6f-7a69-4569-8a25-2e0a3eba0207" />


## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive docstrings, including context and API