### PR TITLE
Preparing laser rate selector to operate at 120hz (AC synced)

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,0 @@
-PYTHONPATH=/cds/home/opr/rixopr/git/lcls2_101824/psdaq:$PYTHONPATH

--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+PYTHONPATH=/cds/home/opr/rixopr/git/lcls2_101824/psdaq:$PYTHONPATH

--- a/opcpa_tpr_config/nc_metadata.ui
+++ b/opcpa_tpr_config/nc_metadata.ui
@@ -24,55 +24,41 @@
       </font>
      </property>
      <property name="text">
-      <string>SC X-ray Status</string>
+      <string>NC X-ray Status</string>
      </property>
     </widget>
    </item>
    <item>
     <layout class="QGridLayout" name="sc_grid_layout">
-     <item row="0" column="1">
-      <widget class="PyDMLabel" name="pattern_name_rbv">
+     <item row="1" column="1">
+      <widget class="PyDMLabel" name="nc_rate_rbv">
        <property name="toolTip">
         <string/>
        </property>
        <property name="alignment">
         <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="1">
-      <widget class="PyDMLabel" name="time_source_rbv">
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="0">
-      <widget class="QLabel" name="offset_rbv_label">
-       <property name="text">
-        <string>Offset RBV</string>
        </property>
       </widget>
      </item>
      <item row="4" column="0">
-      <widget class="QLabel" name="time_slot_label">
+      <widget class="QLabel" name="time_slot_mask_label">
        <property name="text">
-        <string>Time Slot</string>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="0">
-      <widget class="QLabel" name="name_label">
-       <property name="text">
-        <string>Name</string>
+        <string>Time Slot Mask</string>
        </property>
       </widget>
      </item>
      <item row="4" column="1">
-      <widget class="PyDMLabel" name="time_slot_rbv">
+      <widget class="PyDMLabel" name="nc_time_slot_mask_rbv">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="PyDMLabel" name="nc_pattern_name_rbv">
        <property name="toolTip">
         <string/>
        </property>
@@ -95,18 +81,8 @@
        </property>
       </widget>
      </item>
-     <item row="1" column="1">
-      <widget class="PyDMLabel" name="rate_rbv">
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
      <item row="3" column="1">
-      <widget class="PyDMLabel" name="offset_rbv">
+      <widget class="PyDMLabel" name="nc_time_slot_rbv">
        <property name="toolTip">
         <string/>
        </property>
@@ -115,20 +91,27 @@
        </property>
       </widget>
      </item>
-     <item row="5" column="0">
-      <widget class="QLabel" name="time_slot_mask_label">
+     <item row="3" column="0">
+      <widget class="QLabel" name="time_slot_label">
        <property name="text">
-        <string>Time Slot Mask</string>
+        <string>Time Slot</string>
        </property>
       </widget>
      </item>
-     <item row="5" column="1">
-      <widget class="PyDMLabel" name="time_slot_mask_rbv">
+     <item row="2" column="1">
+      <widget class="PyDMLabel" name="nc_time_source_rbv">
        <property name="toolTip">
         <string/>
        </property>
        <property name="alignment">
         <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="0">
+      <widget class="QLabel" name="name_label">
+       <property name="text">
+        <string>Name</string>
        </property>
       </widget>
      </item>

--- a/opcpa_tpr_config/neh_bay2_config.yaml
+++ b/opcpa_tpr_config/neh_bay2_config.yaml
@@ -2,7 +2,8 @@
 
 main:
     xpm_pv: "DAQ:NEH:XPM:0"
-    meta_pv: "TPG:SYS0:1:DST04"
+    sc_meta_pv: "TPG:SYS0:1:DST04"
+    nc_meta_pv: "TODO"
     notepad_pv: "LAS:NEH:BAY2:PVPAD"
     engine1: "4"
     engine2: "5"

--- a/opcpa_tpr_config/neh_bay3_config.yaml
+++ b/opcpa_tpr_config/neh_bay3_config.yaml
@@ -2,7 +2,8 @@
 
 main:
     xpm_pv: "DAQ:NEH:XPM:0"
-    meta_pv: "TPG:SYS0:1:DST04"
+    sc_meta_pv: "TPG:SYS0:1:DST04"
+    nc_meta_pv: "TODO"
     notepad_pv: "LAS:NEH:BAY3:PVPAD"
     engine1: "6"
     engine2: "7"

--- a/opcpa_tpr_config/rep_rate_config.ui
+++ b/opcpa_tpr_config/rep_rate_config.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>279</width>
-    <height>410</height>
+    <height>443</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -172,7 +172,7 @@
         </item>
         <item>
          <property name="text">
-          <string>TS2</string>
+          <string>TS4</string>
          </property>
         </item>
        </widget>

--- a/opcpa_tpr_config/rep_rate_config.ui
+++ b/opcpa_tpr_config/rep_rate_config.ui
@@ -356,7 +356,7 @@
            </widget>
           </item>
           <item>
-           <widget class="PyDMLabel" name="sc_bucket_rbv_2">
+           <widget class="PyDMLabel" name="nc_bucket_rbv">
             <property name="toolTip">
              <string/>
             </property>

--- a/opcpa_tpr_config/rep_rate_config.ui
+++ b/opcpa_tpr_config/rep_rate_config.ui
@@ -341,7 +341,7 @@
              <string>99</string>
             </property>
             <property name="text">
-             <string>7</string>
+             <string>0</string>
             </property>
             <property name="alignment">
              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>

--- a/opcpa_tpr_config/rep_rate_config.ui
+++ b/opcpa_tpr_config/rep_rate_config.ui
@@ -139,103 +139,166 @@
     </layout>
    </item>
    <item>
-    <layout class="QVBoxLayout" name="sc_bucket_layout">
-     <item>
-      <layout class="QHBoxLayout" name="sc_bucket_ctl_layout">
-       <item>
-        <widget class="QLabel" name="sc_start_bucket_control_label">
+    <widget class="QWidget" name="start_timeslot_inputs" native="true">
+     <layout class="QHBoxLayout" name="horizontalLayout_3">
+      <property name="spacing">
+       <number>0</number>
+      </property>
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="QLabel" name="nc_timeslot_label">
+        <property name="text">
+         <string>Start Timeslot</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QComboBox" name="nc_timeslot_selector">
+        <item>
          <property name="text">
-          <string>Start Bucket Control</string>
+          <string>TS1</string>
          </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QComboBox" name="sc_bucket_control_box"/>
-       </item>
-      </layout>
-     </item>
-     <item>
-      <layout class="QHBoxLayout" name="sc_bucket_set_layout">
-       <item>
-        <widget class="QLabel" name="sc_start_bucket_label">
+        </item>
+        <item>
          <property name="text">
-          <string>Start Bucket</string>
+          <string>TS2</string>
          </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QLineEdit" name="sc_bucket_edit">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="inputMask">
-          <string>9</string>
-         </property>
-         <property name="text">
-          <string>0</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QLabel" name="sc_bucket_rbv_label">
-         <property name="text">
-          <string>RBV: </string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="PyDMLabel" name="sc_bucket_rbv">
-         <property name="toolTip">
-          <string/>
-         </property>
-         <property name="text">
-          <string>##</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="PyDMByteIndicator" name="sc_bucket_is_synced">
-         <property name="toolTip">
-          <string/>
-         </property>
-         <property name="channel" stdset="0">
-          <string/>
-         </property>
-         <property name="showLabels" stdset="0">
-          <bool>false</bool>
-         </property>
-         <property name="labels" stdset="0">
-          <stringlist notr="true">
-           <string>Is Synced</string>
-          </stringlist>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="PyDMLabel" name="sc_bucket_is_synced_label">
-         <property name="toolTip">
-          <string/>
-         </property>
-         <property name="text">
-          <string/>
-         </property>
-         <property name="rules" stdset="0">
-          <string>[]</string>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </item>
-    </layout>
+        </item>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QWidget" name="start_bucket_inputs" native="true">
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <property name="spacing">
+       <number>5</number>
+      </property>
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <layout class="QVBoxLayout" name="sc_bucket_layout">
+        <item>
+         <layout class="QHBoxLayout" name="sc_bucket_ctl_layout">
+          <item>
+           <widget class="QLabel" name="sc_start_bucket_control_label">
+            <property name="text">
+             <string>Start Bucket Control</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QComboBox" name="sc_bucket_control_box"/>
+          </item>
+         </layout>
+        </item>
+        <item>
+         <layout class="QHBoxLayout" name="sc_bucket_set_layout">
+          <item>
+           <widget class="QLabel" name="sc_start_bucket_label">
+            <property name="text">
+             <string>Start Bucket</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLineEdit" name="sc_bucket_edit">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="inputMask">
+             <string>9</string>
+            </property>
+            <property name="text">
+             <string>0</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="sc_bucket_rbv_label">
+            <property name="text">
+             <string>RBV: </string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="PyDMLabel" name="sc_bucket_rbv">
+            <property name="toolTip">
+             <string/>
+            </property>
+            <property name="text">
+             <string>##</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="PyDMByteIndicator" name="sc_bucket_is_synced">
+            <property name="toolTip">
+             <string/>
+            </property>
+            <property name="channel" stdset="0">
+             <string/>
+            </property>
+            <property name="showLabels" stdset="0">
+             <bool>false</bool>
+            </property>
+            <property name="labels" stdset="0">
+             <stringlist notr="true">
+              <string>Is Synced</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="PyDMLabel" name="sc_bucket_is_synced_label">
+            <property name="toolTip">
+             <string/>
+            </property>
+            <property name="text">
+             <string/>
+            </property>
+            <property name="rules" stdset="0">
+             <string>[]</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
    </item>
    <item>
     <layout class="QHBoxLayout" name="total_rate_layout">
@@ -326,7 +389,7 @@
      </item>
     </layout>
    </item>
-<item>
+   <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>

--- a/opcpa_tpr_config/rep_rate_config.ui
+++ b/opcpa_tpr_config/rep_rate_config.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>279</width>
-    <height>381</height>
+    <height>410</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -181,7 +181,7 @@
     </widget>
    </item>
    <item>
-    <widget class="QWidget" name="start_bucket_inputs" native="true">
+    <widget class="QWidget" name="start_bucket_inputs_sc" native="true">
      <layout class="QVBoxLayout" name="verticalLayout_2">
       <property name="spacing">
        <number>5</number>
@@ -290,6 +290,61 @@
             </property>
             <property name="rules" stdset="0">
              <string>[]</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QWidget" name="start_bucket_inputs_nc" native="true">
+     <layout class="QVBoxLayout" name="verticalLayout_3">
+      <property name="spacing">
+       <number>5</number>
+      </property>
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <layout class="QVBoxLayout" name="nc_bucket_layout">
+        <item>
+         <layout class="QHBoxLayout" name="nc_bucket_set_layout">
+          <item>
+           <widget class="QLabel" name="nc_start_bucket_label">
+            <property name="text">
+             <string>AC - Fixed Offset (Usually 7 for SXR)</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLineEdit" name="nc_bucket_edit">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="inputMask">
+             <string>99</string>
+            </property>
+            <property name="text">
+             <string>7</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
             </property>
            </widget>
           </item>

--- a/opcpa_tpr_config/rep_rate_config.ui
+++ b/opcpa_tpr_config/rep_rate_config.ui
@@ -325,7 +325,7 @@
           <item>
            <widget class="QLabel" name="nc_start_bucket_label">
             <property name="text">
-             <string>AC - Fixed Offset (Usually 7 for SXR)</string>
+             <string>AC -Offset (0 to 13)</string>
             </property>
            </widget>
           </item>
@@ -342,6 +342,26 @@
             </property>
             <property name="text">
              <string>7</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="sc_bucket_rbv_label_2">
+            <property name="text">
+             <string>RBV: </string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="PyDMLabel" name="sc_bucket_rbv_2">
+            <property name="toolTip">
+             <string/>
+            </property>
+            <property name="text">
+             <string>##</string>
             </property>
             <property name="alignment">
              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>

--- a/opcpa_tpr_config/tests/test_sequences.py
+++ b/opcpa_tpr_config/tests/test_sequences.py
@@ -1,0 +1,152 @@
+""" Tests for XPM sequence generation"""
+
+from PyQt5 import QtCore, QtGui, QtWidgets
+import pyqtgraph as pg
+import numpy as np
+import argparse
+import psdaq.seq.seq
+from psdaq.seq.globals import *
+from psdaq.seq.seqplot import *
+from pprint import pprint
+
+from opcpa_tpr_config import xpm_prog
+
+
+def plot_seq(seq_data: tuple):
+    """ Plots the sequence waveform """
+    app = QtWidgets.QApplication([])
+    plot = PatternWaveform()
+    
+    plot.add("Simulation", *seq_data)
+
+    MainWindow = QtWidgets.QMainWindow()
+    centralWidget = QtWidgets.QWidget(MainWindow)
+    vb = QtWidgets.QVBoxLayout()
+    vb.addWidget(plot.gl)
+    centralWidget.setLayout(vb)
+    MainWindow.setCentralWidget(centralWidget)
+    MainWindow.updateGeometry()
+    MainWindow.show()
+
+    app.exec_()
+    
+
+def simulate_sequence(title, instrset, descset, stop=910001, engine=0, acmode=False):
+    """
+    Simulates executing the given instruction set using classes from seqplot.py.
+
+    Parameters
+    ----------
+    title : str
+        The title or name of the sequence simulation.
+    instrset : list
+        A list of instructions to be executed in the simulation.
+    descset : list
+        A list of descriptions corresponding to each instruction.
+    stop : int, optional
+        the number of frames to simulate
+    acmode : bool, optional
+        if following Fixed rate or AC marker  (won't simulate both)
+    
+    Returns
+    -------
+    the sequence object after execution
+        
+    """
+    seq = SeqUser(start=0,stop=stop,acmode=acmode)
+    seq.execute(title,instrset,descset)
+    ydata = np.array(seq.ydata)+int(engine)*4+272
+    return (seq.xdata, ydata)
+
+def sequence_stats(data:tuple, event_defs=None):
+    """
+    Gives basic stats about the generated sequence to confirm the
+    correct number of triggers are generated.
+
+    For now just list event code counts assuming 1 TPG second of frames.
+    """
+    frame_number, event_codes = data
+    event_code_stats = {}
+
+    # Get unique y values and their counts
+    unique_codes, counts = np.unique(event_codes, return_counts=True)
+    sorted_indices = np.argsort(unique_codes)
+    unique_codes = unique_codes[sorted_indices]
+    counts = counts[sorted_indices] 
+
+    #if event_defs is a list, assume names are given in order
+    if event_defs is not None and isinstance(event_defs,list):
+        event_dict = {}
+        for event_code, event_name in zip(unique_codes, event_defs): 
+            event_dict[int(event_code)] = event_name
+        event_defs = event_dict
+
+    # generate a dict for each event code, add counts and event name 
+    for value, count in zip(unique_codes, counts):
+        event_name = "NA" if event_defs is None else event_defs[value]
+        event_code_stats[int(value)] = {"count":int(count), "event_name":event_name}
+
+    # get first instance of each marker, add to dict
+    for xi, yi in zip(frame_number, unique_codes):
+        if yi not in event_code_stats:
+            # (counts, first instance)
+            event_code_stats[yi]["start_frame"] = xi
+
+    return event_code_stats
+
+
+def test_nc_base_sequences():
+    """ Test that the NC Base sequences are simulated properly."""
+    base_sequence_instrset = xpm_prog.make_base_sequence_nc() 
+    event_names = ['70kH', '35kH', '100H', '5H']
+    data = simulate_sequence(
+        "NC Base Sequence", 
+        base_sequence_instrset,
+        event_names,
+        stop=910000,
+        engine=0,
+        acmode=False
+        )
+    pprint(sequence_stats(data, event_names))
+    # plot_seq(data)
+
+def test_nc_sequences():
+    """ 
+    Test base rate trigger for the laser
+    Note: the initial ACRateSync is not simulated here, 
+    as that is not a feature of the simulation library I am using
+    """
+    from opcpa_tpr_config import xpm_prog
+
+    #some definitions
+    event_names = ["On Time", "Goose", "All Shots"]
+
+    #iterate through all rates and offsets
+    all_rates =  xpm_prog.make_base_rates(xpm_prog.nc_factors)
+    for rate in all_rates:
+        base_div = 120//rate
+        goose_rates =  xpm_prog.allowed_goose_rates(rate,all_rates)
+        goose_rates.append(None) # also check no goose
+        for goose_rate in goose_rates:
+            if goose_rate is not None:
+                goose_div = 120//goose_rate
+            else:
+                goose_div = None
+            for start_ts1 in [True, False]:
+                nc_sequence_instrset = xpm_prog.make_sequence_nc(base_div, start_ts1, goose_div) 
+                data = simulate_sequence("NC Sequence", nc_sequence_instrset, event_names , stop=361, engine=0, acmode=True)
+                print(f"\nNC Sequence Rate: {rate} Hz, Goose Rate: {goose_rate}  TS1_start: {start_ts1}")
+                pprint(sequence_stats(data, event_names))
+                #plot select sequences if here if needed
+                if rate == 120 and goose_rate is None:
+                    plot_seq(data)
+
+
+
+if __name__ == "__main__":
+    test_nc_base_sequences()
+    test_nc_sequences()
+    #print some choice AC sequences
+
+
+    

--- a/opcpa_tpr_config/user_config.ui
+++ b/opcpa_tpr_config/user_config.ui
@@ -44,6 +44,32 @@
       </widget>
      </item>
      <item>
+      <widget class="QComboBox" name="nc_sc_selection">
+       <property name="maximumSize">
+        <size>
+         <width>110</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="currentIndex">
+        <number>0</number>
+       </property>
+       <property name="minimumContentsLength">
+        <number>0</number>
+       </property>
+       <item>
+        <property name="text">
+         <string>Copper Linac</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Superconducting Linac</string>
+        </property>
+       </item>
+      </widget>
+     </item>
+     <item>
       <widget class="QCheckBox" name="expert_checkbox">
        <property name="layoutDirection">
         <enum>Qt::RightToLeft</enum>
@@ -104,14 +130,28 @@
         </widget>
        </item>
        <item>
-        <widget class="SCMetadataDisplay" name="sc_metadata_widget" native="true">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-        </widget>
+        <layout class="QVBoxLayout" name="verticalLayout">
+         <item>
+          <widget class="SCMetadataDisplay" name="sc_metadata_widget" native="true">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="SCMetadataDisplay" name="nc_metadata_widget" native="true">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+          </widget>
+         </item>
+        </layout>
        </item>
       </layout>
      </item>

--- a/opcpa_tpr_config/user_config.ui
+++ b/opcpa_tpr_config/user_config.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>217</width>
-    <height>168</height>
+    <width>521</width>
+    <height>304</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -142,7 +142,7 @@
           </widget>
          </item>
          <item>
-          <widget class="SCMetadataDisplay" name="nc_metadata_widget" native="true">
+          <widget class="NCMetadataDisplay" name="nc_metadata_widget" native="true">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
              <horstretch>0</horstretch>
@@ -188,6 +188,12 @@
   </customwidget>
   <customwidget>
    <class>SCMetadataDisplay</class>
+   <extends>QWidget</extends>
+   <header location="global">widgets</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>NCMetadataDisplay</class>
    <extends>QWidget</extends>
    <header location="global">widgets</header>
    <container>1</container>

--- a/opcpa_tpr_config/widgets.py
+++ b/opcpa_tpr_config/widgets.py
@@ -864,8 +864,8 @@ class UserConfigDisplay(Display):
         bay = self._config['main']['bay']
         seqdesc = {0: f"{bay} 71.4kHz", 1: f"{bay} 35.7kHz", 2: f"{bay} 102Hz",
                 3: f"{bay} 5Hz"}
-        instrset = make_base_sequence(self.offset)
 
+        instrset = make_base_sequence(self.offset, firstSyncAC=(not self.is_superconducting))
 
         self.write_xpm_config(seqdesc, instrset, self._BaseSeq, self._engine2)
 

--- a/opcpa_tpr_config/widgets.py
+++ b/opcpa_tpr_config/widgets.py
@@ -153,12 +153,15 @@ class LaserConfigDisplay(Display):
     start_timeslot_inputs: QtWidgets.QWidget
     nc_timeslot_selector: QtWidgets.QComboBox
 
-    start_bucket_inputs: QtWidgets.QWidget
+    start_bucket_inputs_sc: QtWidgets.QWidget
     sc_bucket_control_box: QtWidgets.QComboBox
     sc_bucket_edit: QtWidgets.QLineEdit
     sc_bucket_rbv: pydm_widgets.PyDMLabel
     sc_bucket_is_synced: pydm_widgets.PyDMByteIndicator
     sc_bucket_is_synced_label: pydm_widgets.PyDMLabel
+    
+    start_bucket_inputs_nc: QtWidgets.QWidget
+    nc_bucket_edit: QtWidgets.QLineEdit
 
     timestamp_rbv: pydm_widgets.PyDMLabel
 
@@ -406,8 +409,12 @@ class LaserConfigDisplay(Display):
         self.sc_bucket_edit.setVisible(self.bucket_control_enabled)
 
     @property
-    def manual_bucket(self):
+    def sc_manual_bucket(self):
         return int(self.sc_bucket_edit.text())
+
+    @property
+    def nc_manual_bucket(self):
+        return int(self.nc_bucket_edit.text())
 
 
 class ExpertDisplay(Display):
@@ -700,12 +707,14 @@ class UserConfigDisplay(Display):
             self.sc_metadata_widget.show()
             self.nc_metadata_widget.hide()
             self.laser_config_widget.start_timeslot_inputs.hide()
-            self.laser_config_widget.start_bucket_inputs.show()
+            self.laser_config_widget.start_bucket_inputs_sc.show()
+            self.laser_config_widget.start_bucket_inputs_nc.hide()
         else:
             self.sc_metadata_widget.hide()
             self.nc_metadata_widget.show()
             self.laser_config_widget.start_timeslot_inputs.show()
-            self.laser_config_widget.start_bucket_inputs.hide()
+            self.laser_config_widget.start_bucket_inputs_sc.hide()
+            self.laser_config_widget.start_bucket_inputs_nc.show()
         
 
     @property
@@ -738,13 +747,16 @@ class UserConfigDisplay(Display):
         """
         Return the SC bucket offset to be used in pattern generation.
         """
-        # Use manual SC bucket if enabled
-        if self.laser_config_widget.bucket_control_enabled:
-            val = self.laser_config_widget.manual_bucket
-        # Otherwise try to detect offset from AD PVs
+        if self.is_superconducting:
+            # Use manual SC bucket if enabled
+            if self.laser_config_widget.bucket_control_enabled:
+                val = self.laser_config_widget.nc_manual_bucket
+            # Otherwise try to detect offset from AD PVs
+            else:
+                # This is a float PV for some reason
+                val = int(self.sc_metadata_widget.offset_rbv.value)
         else:
-            # This is a float PV for some reason
-            val = int(self.sc_metadata_widget.offset_rbv.value)
+            val = self.laser_config_widget.nc_manual_bucket
 
         return val
 
@@ -852,10 +864,7 @@ class UserConfigDisplay(Display):
         bay = self._config['main']['bay']
         seqdesc = {0: f"{bay} 71.4kHz", 1: f"{bay} 35.7kHz", 2: f"{bay} 102Hz",
                 3: f"{bay} 5Hz"}
-        if self.is_superconducting:
-            instrset = make_base_sequence(self.offset)
-        else:
-            instrset = make_base_sequence(None)
+        instrset = make_base_sequence(self.offset)
 
 
         self.write_xpm_config(seqdesc, instrset, self._BaseSeq, self._engine2)

--- a/opcpa_tpr_config/widgets.py
+++ b/opcpa_tpr_config/widgets.py
@@ -157,6 +157,7 @@ class LaserConfigDisplay(Display):
     sc_bucket_control_box: QtWidgets.QComboBox
     sc_bucket_edit: QtWidgets.QLineEdit
     sc_bucket_rbv: pydm_widgets.PyDMLabel
+    nc_bucket_rbv: pydm_widgets.PyDMLabel
     sc_bucket_is_synced: pydm_widgets.PyDMByteIndicator
     sc_bucket_is_synced_label: pydm_widgets.PyDMLabel
     
@@ -260,6 +261,7 @@ class LaserConfigDisplay(Display):
         # "Notepad" PVs
         notepad_pv = self._config['main']['notepad_pv']
         self.sc_bucket_rbv.set_channel(f"ca://{notepad_pv}:SC_BUCKET")
+        self.nc_bucket_rbv.set_channel(f"ca://{notepad_pv}:SC_BUCKET")
         self.timestamp_rbv.set_channel(f"ca://{notepad_pv}:SC_TIMESTAMP")
 
         # start buckets synced indicator

--- a/opcpa_tpr_config/widgets.py
+++ b/opcpa_tpr_config/widgets.py
@@ -310,7 +310,7 @@ class LaserConfigDisplay(Display):
         # Restrict allowed rates to > 1kHz for sc and >5hz for NC, but keep all rates in
         # self._base_rates for allowed goose rate calculation
         if is_superconducting:
-            rate_limit = 100
+            rate_limit = 300
         else:
             rate_limit = 5
         for rate in self._base_rates:

--- a/opcpa_tpr_config/widgets.py
+++ b/opcpa_tpr_config/widgets.py
@@ -14,8 +14,8 @@ from pydm import widgets as pydm_widgets
 from qtpy import QtWidgets
 from xpm_prog import (allowed_goose_rates, sc_factors, nc_factors,
                 make_base_rates,
-                make_base_sequence_sc, make_sequence_sc,
-                make_base_sequence_nc, make_sequence_nc
+                make_base_sequence, make_sequence_sc,
+                make_sequence_nc
                 )
 
 logger = logging.getLogger(__name__)
@@ -310,7 +310,7 @@ class LaserConfigDisplay(Display):
         # Restrict allowed rates to > 1kHz for sc and >5hz for NC, but keep all rates in
         # self._base_rates for allowed goose rate calculation
         if is_superconducting:
-            rate_limit = 1000
+            rate_limit = 100
         else:
             rate_limit = 5
         for rate in self._base_rates:
@@ -850,14 +850,12 @@ class UserConfigDisplay(Display):
             print(f"Offset: {self.offset}")
 
         bay = self._config['main']['bay']
+        seqdesc = {0: f"{bay} 71.4kHz", 1: f"{bay} 35.7kHz", 2: f"{bay} 102Hz",
+                3: f"{bay} 5Hz"}
         if self.is_superconducting:
-            instrset = make_base_sequence_sc(self.offset)
-            seqdesc = {0: f"{bay} 910kHz", 1: f"{bay} 32.5kHz", 2: f"{bay} 100Hz",
-                    3: f"{bay} 5Hz"}
+            instrset = make_base_sequence(self.offset)
         else:
-            instrset = make_base_sequence_nc()
-            seqdesc = {0: f"{bay} 71.4kHz", 1: f"{bay} 35.7kHz", 2: f"{bay} 102Hz",
-                    3: f"{bay} 5Hz"}
+            instrset = make_base_sequence(None)
 
 
         self.write_xpm_config(seqdesc, instrset, self._BaseSeq, self._engine2)

--- a/opcpa_tpr_config/widgets.py
+++ b/opcpa_tpr_config/widgets.py
@@ -73,15 +73,6 @@ class NCMetadataDisplay(Display):
 
         # self.pattern_name_rbv.set_channel(f"ca://{nc_base}:NAME")
 
-    def set_visibility(self, visible):
-        """
-        Update visibility of "expert mode" widgets based on expert mode check
-        box status.
-        """
-        self.xpm_table.setVisible(visible)
-        self.tpr_frame.setVisible(visible)
-        self.rbv_frame.setVisible(visible)
-
     def ui_filename(self):
         return "nc_metadata.ui"
 
@@ -705,12 +696,14 @@ class UserConfigDisplay(Display):
         # self.laser_config_widget.goose_arrival_box.setCurrentIndex(0)
 
         # update visibilities of key widgets
-        self.sc_metadata_widget.setVisible(self.is_superconducting)
-        self.nc_metadata_widget.setVisible(not self.is_superconducting)
         if self.is_superconducting:
+            self.sc_metadata_widget.show()
+            self.nc_metadata_widget.hide()
             self.laser_config_widget.start_timeslot_inputs.hide()
             self.laser_config_widget.start_bucket_inputs.show()
         else:
+            self.sc_metadata_widget.hide()
+            self.nc_metadata_widget.show()
             self.laser_config_widget.start_timeslot_inputs.show()
             self.laser_config_widget.start_bucket_inputs.hide()
         

--- a/opcpa_tpr_config/widgets.py
+++ b/opcpa_tpr_config/widgets.py
@@ -12,8 +12,11 @@ from psdaq.seq.seqprogram import SeqUser
 from pydm import Display
 from pydm import widgets as pydm_widgets
 from qtpy import QtWidgets
-from xpm_prog import (allowed_goose_rates, carbide_factors, make_base_rates,
-                      make_base_sequence, make_sequence)
+from xpm_prog import (allowed_goose_rates, sc_factors, nc_factors,
+                make_base_rates,
+                make_base_sequence_sc, make_sequence_sc,
+                make_base_sequence_nc, make_sequence_nc
+                )
 
 logger = logging.getLogger(__name__)
 
@@ -25,6 +28,67 @@ def read_config(config_file):
     with open(config_file, "r") as f:
         conf = yaml.safe_load(f)
     return conf
+
+class NCMetadataDisplay(Display):
+    """
+    Class for copper linac xray metatdata user display.
+    """
+    def __init__(
+        self,
+        parent=QtWidgets.QWidget,
+        **kwargs
+    ):
+        super().__init__(parent, **kwargs)
+
+    def setup_display(self, config, debug):
+        """
+        Run the things we would run during init but can't because I can't
+        figure out how to pass variables to sub-displays at init....
+        """
+        self._debug = debug
+
+        self._config = read_config(config)
+        if self._config is None:
+            raise ValueError(f"Could not read config file {config}")
+
+        if self._debug:
+            print(f"Read configuration file: {config}")
+            cfg_keys = self._config.keys()
+            print(f"Configuration sections: {cfg_keys}")
+            print(self._config)
+
+        self.update_pvs()
+
+    def update_pvs(self):
+        """
+        Modify RBV widgets to use the PV(s) specified in the config file.
+        """
+        #  metadata
+        nc_base = self._config['main']['nc_meta_pv']
+
+        if self._debug:
+            print(f"SC metadata base PV: {nc_base}")
+
+        # TODO: find relevant NC metadata PVs to display
+
+        # self.pattern_name_rbv.set_channel(f"ca://{nc_base}:NAME")
+
+    def set_visibility(self, visible):
+        """
+        Update visibility of "expert mode" widgets based on expert mode check
+        box status.
+        """
+        self.xpm_table.setVisible(visible)
+        self.tpr_frame.setVisible(visible)
+        self.rbv_frame.setVisible(visible)
+
+    def ui_filename(self):
+        return "nc_metadata.ui"
+
+    def ui_filepath(self):
+        return path.join(
+            path.dirname(path.realpath(__file__)), self.ui_filename()
+        )
 
 
 class SCMetadataDisplay(Display):
@@ -62,7 +126,7 @@ class SCMetadataDisplay(Display):
         Modify RBV widgets to use the PV(s) specified in the config file.
         """
         # SC metadata
-        sc_base = self._config['main']['meta_pv']
+        sc_base = self._config['main']['sc_meta_pv']
 
         if self._debug:
             print(f"SC metadata base PV: {sc_base}")
@@ -95,6 +159,10 @@ class LaserConfigDisplay(Display):
     all_shots_ec_rbv: pydm_widgets.PyDMLabel
     all_shots_rate_rbv: pydm_widgets.PyDMLabel
 
+    start_timeslot_inputs: QtWidgets.QWidget
+    nc_timeslot_selector: QtWidgets.QComboBox
+
+    start_bucket_inputs: QtWidgets.QWidget
     sc_bucket_control_box: QtWidgets.QComboBox
     sc_bucket_edit: QtWidgets.QLineEdit
     sc_bucket_rbv: pydm_widgets.PyDMLabel
@@ -148,9 +216,8 @@ class LaserConfigDisplay(Display):
 
         self.update_pvs()
 
-        self._base_rates = make_base_rates(carbide_factors)
-
-        self.update_base_rates()
+        self._base_rates: list = make_base_rates(nc_factors)
+        self.update_base_rates(False)
 
         self.update_goose_rates()
         self.update_goose_arrival()
@@ -202,7 +269,7 @@ class LaserConfigDisplay(Display):
         self.timestamp_rbv.set_channel(f"ca://{notepad_pv}:SC_TIMESTAMP")
 
         # start buckets synced indicator
-        sc_base = self._config['main']['meta_pv']
+        sc_base = self._config['main']['sc_meta_pv']
         self.sc_bucket_is_synced.set_channel(
             f"calc://compare_buckets?"
             f"laser_bucket=ca://{notepad_pv}:SC_BUCKET&"
@@ -242,21 +309,39 @@ class LaserConfigDisplay(Display):
             path.dirname(path.realpath(__file__)), self.ui_filename()
         )
 
-    def update_base_rates(self):
-        if self._base_rates is not None:
-            for rate in self._base_rates:
-                # Restrict allowed rates to > 1kHz, but keep all rates in
-                # self._base_rates for allowed goose rate calculation
-                # TODO: The calculation of goose rates could probably be
-                # decoupled from the base rate array.
-                if rate >= 1000:
-                    self.total_rate_box.addItem(str(rate))
-            if self._debug:
-                print(f"Allowed base rates: {self._base_rates}")
+    def update_base_rates(self, is_superconducting):
+        if is_superconducting:
+            factors = sc_factors
+        else:
+            factors = nc_factors
+        
+        self._base_rates = make_base_rates(factors)
+        # Restrict allowed rates to > 1kHz for sc and >5hz for NC, but keep all rates in
+        # self._base_rates for allowed goose rate calculation
+        if is_superconducting:
+            rate_limit = 1000
+        else:
+            rate_limit = 5
+        for rate in self._base_rates:
+            # TODO: The calculation of goose rates could probably be
+            # decoupled from the base rate array.
+            if rate <rate_limit:
+                continue
+            self.total_rate_box.addItem(str(rate))
+        
+        # always select the highest rate when switching menus
+        self.total_rate_box.setCurrentIndex(self.total_rate_box.count() - 1)
+
+        if self._debug:
+            print(f"Allowed base rates: {self._base_rates}")
 
     @property
     def base_rate(self):
-        return int(self.total_rate_box.currentText())
+        text_selection = self.total_rate_box.currentText()
+        if text_selection == "":
+            #needed when switching between NC and SC
+            return None
+        return int(text_selection)
 
     def update_goose_vis(self):
         """
@@ -267,7 +352,7 @@ class LaserConfigDisplay(Display):
         self.goose_rate_label.setVisible(self.goose_enabled)
 
     def update_goose_rates(self):
-        if self._base_rates is not None:
+        if self._base_rates is not None and self.base_rate is not None:
             goose_rates = allowed_goose_rates(
                 self.base_rate,
                 self._base_rates
@@ -312,6 +397,11 @@ class LaserConfigDisplay(Display):
         modes = ['Manual', 'Auto']
         for mode in modes:
             self.sc_bucket_control_box.addItem(mode)
+
+    @property
+    def start_ts1(self) -> bool:
+        """  Starts on TS1 if True, TS4 if False"""
+        return self.nc_timeslot_selector.currentIndex() == 0
 
     @property
     def bucket_control_enabled(self):
@@ -522,9 +612,13 @@ class UserConfigDisplay(Display):
 
     # Top level widgets
     screen_title: pydm_widgets.PyDMLabel
+    nc_sc_selection: QtWidgets.QComboBox
 
     # SC Metadata
     sc_metadata_widget: SCMetadataDisplay
+
+    # NC Metadata
+    nc_metadata_widget: NCMetadataDisplay
 
     # Laser Config
     laser_config_widget: LaserConfigDisplay
@@ -545,6 +639,8 @@ class UserConfigDisplay(Display):
         self.laser_config_widget.setup_display(config, debug)
 
         self.sc_metadata_widget.setup_display(config, debug)
+
+        self.nc_metadata_widget.setup_display(config, debug)
 
         self.expert_display_widget.setup_display(config, debug)
 
@@ -572,10 +668,16 @@ class UserConfigDisplay(Display):
 
         self.update_expert_vis()
 
+        self.update_sc_nc()
+
         self.laser_config_widget.apply_button.clicked.connect(
             self.apply_config
         )
         self.expert_checkbox.stateChanged.connect(self.update_expert_vis)
+
+        self.nc_sc_selection.currentIndexChanged.connect(
+            self.update_sc_nc
+        )
 
     def ui_filename(self):
         return "user_config.ui"
@@ -587,6 +689,31 @@ class UserConfigDisplay(Display):
 
     def update_expert_vis(self):
         self.expert_display_widget.set_visibility(self.expert_mode)
+
+
+    def update_sc_nc(self):
+        """
+        Resets widgets based on user selections of Linac type (NC or SC).
+        """
+        # first clear previous rates
+        self._base_rates = None
+        self.laser_config_widget.total_rate_box.clear()
+
+        #then re_init them
+        self.laser_config_widget.update_base_rates(self.is_superconducting)
+        # always reset goose config selection
+        # self.laser_config_widget.goose_arrival_box.setCurrentIndex(0)
+
+        # update visibilities of key widgets
+        self.sc_metadata_widget.setVisible(self.is_superconducting)
+        self.nc_metadata_widget.setVisible(not self.is_superconducting)
+        if self.is_superconducting:
+            self.laser_config_widget.start_timeslot_inputs.hide()
+            self.laser_config_widget.start_bucket_inputs.show()
+        else:
+            self.laser_config_widget.start_timeslot_inputs.show()
+            self.laser_config_widget.start_bucket_inputs.hide()
+        
 
     @property
     def debug(self):
@@ -608,6 +735,10 @@ class UserConfigDisplay(Display):
     @property
     def expert_mode(self):
         return self.expert_checkbox.isChecked()
+    
+    @property
+    def is_superconducting(self):
+        return self.nc_sc_selection.currentIndex() == 1
 
     @property
     def offset(self):
@@ -687,9 +818,12 @@ class UserConfigDisplay(Display):
         Generate and apply the XPM configuration for the laser on/off time
         event codes.
         """
-        base_div = 910000//self.laser_config_widget.base_rate
+
+        fiducials_per_period = 910000 if self.is_superconducting else 120        
+
+        base_div = fiducials_per_period//self.laser_config_widget.base_rate
         if self.laser_config_widget.goose_enabled:
-            goose_div = 910000//self.laser_config_widget.goose_rate
+            goose_div = fiducials_per_period//self.laser_config_widget.goose_rate
         else:
             goose_div = None
 
@@ -702,7 +836,10 @@ class UserConfigDisplay(Display):
             print(f"Goose div: {goose_div}")
             print(f"Offset: {self.offset}")
 
-        instrset = make_sequence(base_div, goose_div, self.offset, self._debug)
+        if self.is_superconducting:
+            instrset = make_sequence_sc(base_div, goose_div, self.offset, self._debug)
+        else:
+            instrset = make_sequence_nc(base_div, self.laser_config_widget.start_ts1, goose_div) 
 
         bay = self._config['main']['bay']
         seqdesc = {0: f"{bay} On time shots", 1: f"{bay} Goose shots",
@@ -719,11 +856,16 @@ class UserConfigDisplay(Display):
             print("Applying base rates")
             print(f"Offset: {self.offset}")
 
-        instrset = make_base_sequence(self.offset)
-
         bay = self._config['main']['bay']
-        seqdesc = {0: f"{bay} 910kHz", 1: f"{bay} 32.5kHz", 2: f"{bay} 100Hz",
-                   3: f"{bay} 5Hz"}
+        if self.is_superconducting:
+            instrset = make_base_sequence_sc(self.offset)
+            seqdesc = {0: f"{bay} 910kHz", 1: f"{bay} 32.5kHz", 2: f"{bay} 100Hz",
+                    3: f"{bay} 5Hz"}
+        else:
+            instrset = make_base_sequence_nc()
+            seqdesc = {0: f"{bay} 71.4kHz", 1: f"{bay} 35.7kHz", 2: f"{bay} 102Hz",
+                    3: f"{bay} 5Hz"}
+
 
         self.write_xpm_config(seqdesc, instrset, self._BaseSeq, self._engine2)
 

--- a/opcpa_tpr_config/xpm_prog.py
+++ b/opcpa_tpr_config/xpm_prog.py
@@ -7,12 +7,13 @@ from psdaq.seq.seq import Branch, ControlRequest, FixedRateSync, ACRateSync, acR
 from psdaq.seq.seqprogram import SeqUser
 
 factors = [2, 2, 2, 2, 5, 5, 5, 5, 7, 13]  # 910,000
-carbide_factors = [1, 2, 2, 5, 5, 5, 5, 13]  # 32,500 (remove 2, 2, 7, add 1)
+sc_factors = [1, 2, 2, 5, 5, 5, 5, 13]  # 32,500 (remove 2, 2, 7, add 1)
+nc_factors = [2, 2, 2, 3, 5]# 120Hz  (independent of 910k factors)
 
 
 def make_base_rates(laser_factors):
     """
-    Generate a dictionary of factors --> rates (TPG second)
+    Generate a list of factors --> rates (TPG second)
     """
     iters = [
         itertools.combinations(
@@ -88,8 +89,8 @@ def make_sequence_nc(base_div, start_ts1 = True, goose_div=None, debug=False):
     Generate an AC sequence at spacing of base_div times the base (120hz) rate for
     NC operation. 
 
-    NOTE: AC baser rates are in terms of every timeslot. Sync instructions must specify
-    a timeslot mask and a rate. There are 6 time slots each with sub 60H rate markers.
+    NOTE:  AC base rates always need to specify a timeslot. 
+           There are 6 time slots each with 60H rate markers.
 
     Parameters
     ----------
@@ -159,73 +160,78 @@ def make_base_sequence_nc():
     """
     Setup lase base rate sequences needed for running NC mode.
 
-    Rates: Full AC Rate 71,428, 35,714 
+    Rates: AC Rate 71,428, 35,714, 102, 5.1 Hz
+            70k, 35k, 100, 5 (TPG seconds)
 
-    Notes:
+    Notes
     ----
 
-    The AC power line is sampled at 1/14Mhz = 71428 Hz, 
-    so all AC crossings (LCLS 1 fiducials) are guaranteed to line 
-    up with the 71428 Hz markers.
+    The AC power line is sampled at 2/14Mhz = 35,714 Hz 
+    to guaranteed all AC crossings coincide every two 71428 Hz markers.
 
-    For carbide lasers we want to run at 35714 Hz subharmonic of 71428 Hz, 
-    having only 50% overlap with the AC crossings.
-
-    My understanding is that there is no guaranteed pattern that ensures 
-    the 35714 Hz rates will line up with the AC crossings every time,
-    because the grid voltage is not phase locked to 
-    the master occilator.
-
-    Therefore we need to "resync" to every AC marker available (360hz)
-    such that the 35714 Hz shots always line up with the AC crossings.
-
-    We might need to include more rates after disusing with lasers
- 
-    The simulator is unable to mix ac and fixed rate commands so
-    this is not tested yet.
-    ( simulations show either 910000 buckets or 
-    360 buckets frames but not at the same time)
+    To ensure we start at the correct phase, we need to sync to the AC crossing
+    before starting the 71428 Hz fixed rate sequence.
 
     """
     # initialize instruction set array
     instrset = []
     fiducial_marker = acRateHzToMarker["60Hz"] 
-    timeslot_mask = (1<<0) | (1<<1) | (1<<2) | (1<<3) # all timeslots
+     # Linac only fires on TS 1 and 4
+    timeslot_mask = (1<<0) | (1<<3)
 
+    # No need to worry about starting offsets for base rates
 
-    # No need to worry about starting offsets 
-    branch_0 = len(instrset)
-    # first sync to any of the AC crossings 
-    # (we need to trigger the 35khz we don't miss xray shots)
+    # first sync to linac to ensure in phase
     instrset.append(ACRateSync(timeslotm=timeslot_mask, marker=fiducial_marker, occ=1))
-    instrset.append(ControlRequest([0, 1])) # 70kH + 35kH
-    # after the synced AC crossing, there should be at least 198, 70KH markers
-    # and 99 35kH markers before the next AC crossing
-    #     (1/360) / (1/71,428) = ~198.4111    => / 2 = ~99.2055
-    
-    # 70k marker only 
-    instrset.append(FixedRateSync(marker="70kH", occ=1))
-    instrset.append(ControlRequest([0])) # 70kH only
 
-    # loop 98 times * 2 70 markerks = 196 + initial one = 197 markers)
+    branch_0 = len(instrset)
+    instrset.append(ControlRequest([0, 1, 2, 3])) # 70kH + 35kH + 100H + 5H
+    instrset.append(FixedRateSync(marker="70kH", occ=1))
+
     branch_1 = len(instrset)
+    _add_inner_sequence(instrset)
+
+    ## Loop 2: 100H markers per 5H marker
+    spacing_100 = 700
+    spacing_5 = 14000
+    loop_count = spacing_5 // spacing_100 - 2
+    instrset.append(Branch.conditional(line=branch_1, counter=1, value=loop_count))
+    # again last iteration has to be done manually
+    _add_inner_sequence(instrset , final=True)
+
+    instrset.append(Branch.unconditional(line=branch_0))
+
+    return instrset
+
+def _add_inner_sequence(instrset: list, final=False):
+    """
+    To make the nc sequence a little more readable, 
+    a repeated section is broken out here
+
+    Loop 1:
+    75kH + 35kH markers per 100H marker 
+    
+    final = true, do not add 100H last marker
+    """
+    # define all spacings in terms of smallest marker
+    # spacing_70k = 1
+    spacing_35k = 2
+    spacing_100 = 700
+
+    loop_count = spacing_100//spacing_35k - 2 
+    branch = len(instrset)
+    instrset.append(ControlRequest([0])) # 70kH 
     instrset.append(FixedRateSync(marker="70kH", occ=1))
     instrset.append(ControlRequest([0, 1])) # 70kH + 35kH
     instrset.append(FixedRateSync(marker="70kH", occ=1))
-    instrset.append(ControlRequest([0])) # 70kH only
-    instrset.append(Branch.conditional(line=branch_1, counter=0, value=98))
-
-    # last 70k marker before next AC sync == 198th marker 
-    # might need to take this line out (see next comment!)
+    instrset.append(Branch.conditional(line=branch, counter=0, value=loop_count))
+    # last iteration done manually since last iteration is different
+    instrset.append(ControlRequest([0])) # 70kH 
     instrset.append(FixedRateSync(marker="70kH", occ=1))
-    instrset.append(ControlRequest([0])) # 70kH only
+    if not final:
+        instrset.append(ControlRequest([0, 1, 2])) # 70kH, 35kH, 100H 
+        instrset.append(FixedRateSync(marker="70kH", occ=1))
 
-    #NOTE I am forcing the next AC sync
-    #  depending on how the AC is sampled by the sep down chassis
-    #  the sequence is either 1 or 2 70khz periods from from the AC crossing trigger 
-    #  This  will introduce jitter in the 35kHz rate but ensures we don't miss shots.
-    # I don't know if there is a better way to handle this with the current hardware
-    instrset.append(Branch.unconditional(line=branch_0))
     return instrset
 
 def make_base_sequence_sc(offset=None):
@@ -303,7 +309,7 @@ if __name__ == "__main__":
     engines = {2: 6, 3: 7}  # Bay --> sequence engine mapping
 
     # Dict will eventually be applied to drop down menu
-    base_list = make_base_rates(sc_carbide_factors)
+    base_list = make_base_rates(sc_factors)
 
     if base_rate not in base_list:
         raise ValueError(

--- a/opcpa_tpr_config/xpm_prog.py
+++ b/opcpa_tpr_config/xpm_prog.py
@@ -157,7 +157,7 @@ def make_sequence_nc(base_div, start_ts1 = True, goose_div=None, debug=False):
     return instrset
 
 
-def make_base_sequence(offset=None):
+def make_base_sequence(offset=None, firstSyncAC=False):
     """
     Setup base rate sequences always needed to operate the laser system.
 
@@ -181,6 +181,13 @@ def make_base_sequence(offset=None):
 
     if offset is None:
         offset = 0
+
+    if firstSyncAC:
+        timeslot_mask = (1<<0) | (1<<3)
+        fiducial_marker = acRateHzToMarker["60Hz"] 
+        instrset.append(ACRateSync(timeslotm=timeslot_mask, marker=fiducial_marker, occ=1))
+        # needed so first offset_request() starts at a 70H marker
+        instrset.append(FixedRateSync(marker="70kH", occ=2))
 
     branch_0 = len(instrset)
     _add_offset_request(instrset, [0, 1, 2, 3], offset) # 70kH + 35kH + 100H + 5H

--- a/opcpa_tpr_config/xpm_prog.py
+++ b/opcpa_tpr_config/xpm_prog.py
@@ -7,7 +7,7 @@ from psdaq.seq.seq import Branch, ControlRequest, FixedRateSync, ACRateSync, acR
 from psdaq.seq.seqprogram import SeqUser
 
 factors = [2, 2, 2, 2, 5, 5, 5, 5, 7, 13]  # 910,000
-sc_factors = [1, 2, 2, 5, 5, 5, 5, 13]  # 32,500 (remove 2, 2, 7, add 1)
+sc_factors = [2, 2, 2, 5, 5, 5, 5, 7]  # 35000 (remove 13, 2, add 1)
 nc_factors = [2, 2, 2, 3, 5]# 120Hz  (independent of 910k factors)
 
 
@@ -156,9 +156,9 @@ def make_sequence_nc(base_div, start_ts1 = True, goose_div=None, debug=False):
         
     return instrset
 
-def make_base_sequence_nc():
+def make_base_sequence(offset=None):
     """
-    Setup lase base rate sequences needed for running NC mode.
+    Setup base rate sequences always needed to operate the laser system.
 
     Rates: AC Rate 71,428, 35,714, 102, 5.1 Hz
             70k, 35k, 100, 5 (TPG seconds)
@@ -175,14 +175,18 @@ def make_base_sequence_nc():
     """
     # initialize instruction set array
     instrset = []
-    fiducial_marker = acRateHzToMarker["60Hz"] 
-     # Linac only fires on TS 1 and 4
-    timeslot_mask = (1<<0) | (1<<3)
 
-    # No need to worry about starting offsets for base rates
 
-    # first sync to linac to ensure in phase
-    instrset.append(ACRateSync(timeslotm=timeslot_mask, marker=fiducial_marker, occ=1))
+    # # Insert bucket offset if it is present (only possible in sc timing)
+    # if offset is not None and offset != 0:
+    #     instrset.append(FixedRateSync(marker="910kH", occ=offset))
+    # else:
+    #     # first AC Sync to linac to ensure in phase
+    #     # this may not be needed depending on how AC markers are sampled
+    #     fiducial_marker = acRateHzToMarker["60Hz"] 
+    #     # Linac only fires on TS 1 and 4
+    #     timeslot_mask = (1<<0) | (1<<3)
+    #     instrset.append(ACRateSync(timeslotm=timeslot_mask, marker=fiducial_marker, occ=1))
 
     branch_0 = len(instrset)
     instrset.append(ControlRequest([0, 1, 2, 3])) # 70kH + 35kH + 100H + 5H
@@ -233,53 +237,6 @@ def _add_inner_sequence(instrset: list, final=False):
         instrset.append(FixedRateSync(marker="70kH", occ=1))
 
     return instrset
-
-def make_base_sequence_sc(offset=None):
-    """
-    Setup standard sequence of full rate, 32500, 100, and 5 Hz codes.
-    """
-    # Do some setup
-    instrset = []
-
-    # Insert bucket offset if it is present
-    if offset is not None and offset != 0:
-        instrset.append(FixedRateSync(marker="910kH", occ=offset))
-
-    b0 = len(instrset)
-    instrset.append(ControlRequest([0, 1, 2, 3]))
-    instrset.append(FixedRateSync(marker="910kH", occ=1))
-    b1 = len(instrset)
-    instrset.append(ControlRequest([0]))
-    instrset.append(FixedRateSync(marker="910kH", occ=1))
-    instrset.append(Branch.conditional(line=b1, counter=0, value=26))
-    b2 = len(instrset)
-    instrset.append(ControlRequest([0, 1]))
-    instrset.append(FixedRateSync(marker="910kH", occ=1))
-    b3 = len(instrset)
-    instrset.append(ControlRequest([0]))
-    instrset.append(FixedRateSync(marker="910kH", occ=1))
-    instrset.append(Branch.conditional(line=b3, counter=0, value=26))
-    instrset.append(Branch.conditional(line=b2, counter=1, value=323))
-    b4 = len(instrset)
-    instrset.append(ControlRequest([0, 1, 2]))
-    instrset.append(FixedRateSync(marker="910kH", occ=1))
-    b5 = len(instrset)
-    instrset.append(ControlRequest([0]))
-    instrset.append(FixedRateSync(marker="910kH", occ=1))
-    instrset.append(Branch.conditional(line=b5, counter=0, value=26))
-    b6 = len(instrset)
-    instrset.append(ControlRequest([0, 1]))
-    instrset.append(FixedRateSync(marker="910kH", occ=1))
-    b7 = len(instrset)
-    instrset.append(ControlRequest([0]))
-    instrset.append(FixedRateSync(marker="910kH", occ=1))
-    instrset.append(Branch.conditional(line=b7, counter=0, value=26))
-    instrset.append(Branch.conditional(line=b6, counter=1, value=323))
-    instrset.append(Branch.conditional(line=b4, counter=2, value=18))
-    instrset.append(Branch.unconditional(line=b0))
-
-    return instrset
-
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()

--- a/opcpa_tpr_config/xpm_prog.py
+++ b/opcpa_tpr_config/xpm_prog.py
@@ -183,8 +183,8 @@ def make_base_sequence(offset=None):
         offset = 0
 
     branch_0 = len(instrset)
-    instrset.append(FixedRateSync(marker="70kH", occ=1))
     _add_offset_request(instrset, [0, 1, 2, 3], offset) # 70kH + 35kH + 100H + 5H
+    instrset.append(FixedRateSync(marker="70kH", occ=1))
     branch_1 = len(instrset)
     _add_inner_sequence(instrset, offset=offset)
 

--- a/opcpa_tpr_config/xpm_prog.py
+++ b/opcpa_tpr_config/xpm_prog.py
@@ -156,6 +156,7 @@ def make_sequence_nc(base_div, start_ts1 = True, goose_div=None, debug=False):
         
     return instrset
 
+
 def make_base_sequence(offset=None):
     """
     Setup base rate sequences always needed to operate the laser system.
@@ -169,31 +170,23 @@ def make_base_sequence(offset=None):
     The AC power line is sampled at 2/14Mhz = 35,714 Hz 
     to guaranteed all AC crossings coincide every two 71428 Hz markers.
 
-    To ensure we start at the correct phase, we need to sync to the AC crossing
-    before starting the 71428 Hz fixed rate sequence.
+    During testing it was observed the ACRateSync was observed to have an
+    offset of 7 910kH markers from the corresponding 70kH fixedRateSync.
+
+    This offset might change from 7, so the offset selection is kept even for AC rates
 
     """
     # initialize instruction set array
     instrset = []
 
-
-    # # Insert bucket offset if it is present (only possible in sc timing)
-    # if offset is not None and offset != 0:
-    #     instrset.append(FixedRateSync(marker="910kH", occ=offset))
-    # else:
-    #     # first AC Sync to linac to ensure in phase
-    #     # this may not be needed depending on how AC markers are sampled
-    #     fiducial_marker = acRateHzToMarker["60Hz"] 
-    #     # Linac only fires on TS 1 and 4
-    #     timeslot_mask = (1<<0) | (1<<3)
-    #     instrset.append(ACRateSync(timeslotm=timeslot_mask, marker=fiducial_marker, occ=1))
+    if offset is None:
+        offset = 0
 
     branch_0 = len(instrset)
-    instrset.append(ControlRequest([0, 1, 2, 3])) # 70kH + 35kH + 100H + 5H
     instrset.append(FixedRateSync(marker="70kH", occ=1))
-
+    _add_offset_request(instrset, [0, 1, 2, 3], offset) # 70kH + 35kH + 100H + 5H
     branch_1 = len(instrset)
-    _add_inner_sequence(instrset)
+    _add_inner_sequence(instrset, offset=offset)
 
     ## Loop 2: 100H markers per 5H marker
     spacing_100 = 700
@@ -201,13 +194,20 @@ def make_base_sequence(offset=None):
     loop_count = spacing_5 // spacing_100 - 2
     instrset.append(Branch.conditional(line=branch_1, counter=1, value=loop_count))
     # again last iteration has to be done manually
-    _add_inner_sequence(instrset , final=True)
+    _add_inner_sequence(instrset, offset=offset, final=True)
 
     instrset.append(Branch.unconditional(line=branch_0))
 
     return instrset
 
-def _add_inner_sequence(instrset: list, final=False):
+def _add_offset_request(instrset: list, request, offset) -> list:
+    """ helper function adds control requests with appropriate offset"""
+    if offset != 0:
+        instrset.append(FixedRateSync(marker="910kH", occ=offset))
+    instrset.append(ControlRequest(request))
+
+
+def _add_inner_sequence(instrset: list, offset=None, final=False):
     """
     To make the nc sequence a little more readable, 
     a repeated section is broken out here
@@ -224,18 +224,17 @@ def _add_inner_sequence(instrset: list, final=False):
 
     loop_count = spacing_100//spacing_35k - 2 
     branch = len(instrset)
-    instrset.append(ControlRequest([0])) # 70kH 
+    _add_offset_request(instrset, [0], offset) #70kH
     instrset.append(FixedRateSync(marker="70kH", occ=1))
-    instrset.append(ControlRequest([0, 1])) # 70kH + 35kH
+    _add_offset_request(instrset, [0, 1], offset) #70kH + 35KH
     instrset.append(FixedRateSync(marker="70kH", occ=1))
     instrset.append(Branch.conditional(line=branch, counter=0, value=loop_count))
     # last iteration done manually since last iteration is different
-    instrset.append(ControlRequest([0])) # 70kH 
+    _add_offset_request(instrset, [0], offset) #70kH
     instrset.append(FixedRateSync(marker="70kH", occ=1))
     if not final:
-        instrset.append(ControlRequest([0, 1, 2])) # 70kH, 35kH, 100H 
+        _add_offset_request(instrset, [0, 1, 2], offset) #70kH + 35KH + 100H
         instrset.append(FixedRateSync(marker="70kH", occ=1))
-
     return instrset
 
 if __name__ == "__main__":

--- a/opcpa_tpr_config/xpm_prog.py
+++ b/opcpa_tpr_config/xpm_prog.py
@@ -3,7 +3,7 @@ import itertools
 
 import numpy as np
 from psdaq.cas.pvedit import Pv
-from psdaq.seq.seq import Branch, ControlRequest, FixedRateSync
+from psdaq.seq.seq import Branch, ControlRequest, FixedRateSync, ACRateSync, acRateHzToMarker
 from psdaq.seq.seqprogram import SeqUser
 
 factors = [2, 2, 2, 2, 5, 5, 5, 5, 7, 13]  # 910,000
@@ -38,7 +38,7 @@ def allowed_goose_rates(base_rate, rate_list):
 
 
 # Selected base rate + goose rate --> pulse sequence
-def make_sequence(base_div, goose_div=None, offset=None, debug=False):
+def make_sequence_sc(base_div, goose_div=None, offset=None, debug=False):
     # Do some setup
     instrset = []
 
@@ -83,8 +83,152 @@ def make_sequence(base_div, goose_div=None, offset=None, debug=False):
 
     return instrset
 
+def make_sequence_nc(base_div, start_ts1 = True, goose_div=None, debug=False):
+    """
+    Generate an AC sequence at spacing of base_div times the base (120hz) rate for
+    NC operation. 
 
-def make_base_sequence(offset=None):
+    NOTE: AC baser rates are in terms of every timeslot. Sync instructions must specify
+    a timeslot mask and a rate. There are 6 time slots each with sub 60H rate markers.
+
+    Parameters
+    ----------
+    base_div
+       divisor in units of beams (120hz)
+       1 => full rate 120HZ, 2 for 60Hz, 3 for 40Hz, etc.
+       rate = 120 / base_div
+    start_ts1, optional
+        if True, start synced to TS1, else TS4
+        Only changes pattern if rate is a sub-harmonic of 60 Hz
+    goose_div, optional
+        Goose trigger divisor (same units as base_div)
+        Must be integer multiple of base_div!
+    debug, optional
+        add print statements, by default False
+
+    Notes
+    -------
+    
+    Confluence Docs are inconsistent with the library definitions used here! 
+    Confluence examples show that "marker 0" corresponds to 60H rate,
+    but in the acRateHzToMarker dictionary in seq.py, clearly maps "60H" maps to "marker 5".
+
+    I used the library definitions here for correct simulations
+    but this should be verified on hardware!
+    """
+ 
+    # Do some setup
+    instrset = []
+    
+    fiducial_marker = acRateHzToMarker["60Hz"] 
+   
+    # sync the fist shot
+    if start_ts1:
+        timeslot_mask = (1<<0) 
+    else:
+        timeslot_mask = (1<<3)
+    instrset.append(ACRateSync(timeslotm=timeslot_mask, marker=fiducial_marker, occ=1))
+
+    # Linac only fires on TS 1 and 4
+    timeslot_mask = (1<<0) | (1<<3)
+
+    branch_0 = len(instrset)
+    if goose_div not in (None, 0):
+        # goosing
+        ontime_per_goose= (goose_div//base_div) - 1 
+        # goosing shot is first, then # of ontime shots per goose
+        instrset.append(ControlRequest([1, 2])) # goose + all
+        instrset.append(ACRateSync(timeslotm=timeslot_mask, marker=fiducial_marker, occ=base_div))
+        for i in range(ontime_per_goose):
+            instrset.append(ControlRequest([0, 2])) # on_time +all
+            instrset.append(ACRateSync(timeslotm=timeslot_mask, marker=fiducial_marker, occ=base_div))
+        instrset.append(Branch.unconditional(line=branch_0))
+    else:
+        # no goose, only on_time shots
+        instrset.append(ControlRequest([0,2])) #on_time + all
+        instrset.append(ACRateSync(timeslotm=timeslot_mask, marker=fiducial_marker, occ=base_div))
+        instrset.append(Branch.unconditional(line=branch_0))
+
+    if debug:
+        for instr in instrset:
+            print(instr.print_())
+        
+    return instrset
+
+def make_base_sequence_nc():
+    """
+    Setup lase base rate sequences needed for running NC mode.
+
+    Rates: Full AC Rate 71,428, 35,714 
+
+    Notes:
+    ----
+
+    The AC power line is sampled at 1/14Mhz = 71428 Hz, 
+    so all AC crossings (LCLS 1 fiducials) are guaranteed to line 
+    up with the 71428 Hz markers.
+
+    For carbide lasers we want to run at 35714 Hz subharmonic of 71428 Hz, 
+    having only 50% overlap with the AC crossings.
+
+    My understanding is that there is no guaranteed pattern that ensures 
+    the 35714 Hz rates will line up with the AC crossings every time,
+    because the grid voltage is not phase locked to 
+    the master occilator.
+
+    Therefore we need to "resync" to every AC marker available (360hz)
+    such that the 35714 Hz shots always line up with the AC crossings.
+
+    We might need to include more rates after disusing with lasers
+ 
+    The simulator is unable to mix ac and fixed rate commands so
+    this is not tested yet.
+    ( simulations show either 910000 buckets or 
+    360 buckets frames but not at the same time)
+
+    """
+    # initialize instruction set array
+    instrset = []
+    fiducial_marker = acRateHzToMarker["60Hz"] 
+    timeslot_mask = (1<<0) | (1<<1) | (1<<2) | (1<<3) # all timeslots
+
+
+    # No need to worry about starting offsets 
+    branch_0 = len(instrset)
+    # first sync to any of the AC crossings 
+    # (we need to trigger the 35khz we don't miss xray shots)
+    instrset.append(ACRateSync(timeslotm=timeslot_mask, marker=fiducial_marker, occ=1))
+    instrset.append(ControlRequest([0, 1])) # 70kH + 35kH
+    # after the synced AC crossing, there should be at least 198, 70KH markers
+    # and 99 35kH markers before the next AC crossing
+    #     (1/360) / (1/71,428) = ~198.4111    => / 2 = ~99.2055
+    
+    # 70k marker only 
+    instrset.append(FixedRateSync(marker="70kH", occ=1))
+    instrset.append(ControlRequest([0])) # 70kH only
+
+    # loop 98 times * 2 70 markerks = 196 + initial one = 197 markers)
+    branch_1 = len(instrset)
+    instrset.append(FixedRateSync(marker="70kH", occ=1))
+    instrset.append(ControlRequest([0, 1])) # 70kH + 35kH
+    instrset.append(FixedRateSync(marker="70kH", occ=1))
+    instrset.append(ControlRequest([0])) # 70kH only
+    instrset.append(Branch.conditional(line=branch_1, counter=0, value=98))
+
+    # last 70k marker before next AC sync == 198th marker 
+    # might need to take this line out (see next comment!)
+    instrset.append(FixedRateSync(marker="70kH", occ=1))
+    instrset.append(ControlRequest([0])) # 70kH only
+
+    #NOTE I am forcing the next AC sync
+    #  depending on how the AC is sampled by the sep down chassis
+    #  the sequence is either 1 or 2 70khz periods from from the AC crossing trigger 
+    #  This  will introduce jitter in the 35kHz rate but ensures we don't miss shots.
+    # I don't know if there is a better way to handle this with the current hardware
+    instrset.append(Branch.unconditional(line=branch_0))
+    return instrset
+
+def make_base_sequence_sc(offset=None):
     """
     Setup standard sequence of full rate, 32500, 100, and 5 Hz codes.
     """
@@ -159,7 +303,7 @@ if __name__ == "__main__":
     engines = {2: 6, 3: 7}  # Bay --> sequence engine mapping
 
     # Dict will eventually be applied to drop down menu
-    base_list = make_base_rates(carbide_factors)
+    base_list = make_base_rates(sc_carbide_factors)
 
     if base_rate not in base_list:
         raise ValueError(
@@ -179,7 +323,7 @@ if __name__ == "__main__":
     seqdesc = {0: f"Bay {bay} On Time", 1: f"Bay {bay} Off Time", 2: "", 3: ""}
     base_div = 910000//int(base_rate)
     goose_div = 910000//int(goose_rate)
-    inst = make_sequence(base_div, goose_div, offset, True)
+    inst = make_sequence_sc(base_div, goose_div, offset, True)
 
     xpm_pv = "DAQ:NEH:XPM:0"
     seqcodes_pv = Pv(f'{xpm_pv}:SEQCODES', isStruct=True)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->

Created "Normal Conductor" mode for laser rate selection. This meant changing pulse picker rate sequence engine to use AC markers instead of FixedRate (LCLS2) markers. The laser base rate also had to be adjusted from 33kH rate to 35kH (shared subharmonic of LCLS1) for this to work.  

This PR includes GUI changes  with a selector between the modes that toggles visibility of elements as needed. 

- Adds AC Synced (120Hz) sequences for all possible rates down to 5Hz
- new sequences support a similar goosing strategy as before
- Fixed rate sequence for the laser_base was changed from 33kH-> 35kH to support this operation
- added NC specific widgets (Timeslot selection)
- modified rate calculation functions to work with either mode

## Motivation and Context

Starting Run 26/27, the LCLS2 laser lockers in the near hall will need to work with the copper linac (120Hz). To support this mode of operation, this application needed to be modified to program the XPM with the slower AC-synced rates . This is done by utilizing a XMP feature that supports LCLS1 markers on the lcls2 timing stream. We are hoping to test this operation in early February to work out all the kinks before the march experiments.


Technical Background:
https://confluence.slac.stanford.edu/spaces/~weaver/pages/343730216/Timing+Pattern+Generator+Sequence+Programming
https://confluence.slac.stanford.edu/spaces/~weaver/pages/377717909/Experiment+Partition+Master+XPM+Sequence+Programming
https://confluence.slac.stanford.edu/spaces/~weaver/pages/388825472/LCLS-2+Timing+Pattern+Generation+Principles

## How Has This Been Tested?

All sequenced simulated using the python xpm sequence plotter library 
Planning to test on hardware in next two weeks.


## Where Has This Been Documented?
This PR. 


## Screenshots:
<img width="1010" height="550" alt="image" src="https://github.com/user-attachments/assets/95b56b95-673f-46ea-aa93-6e0dc4debc04" />
<img width="1029" height="623" alt="image" src="https://github.com/user-attachments/assets/65d5b581-4494-46f9-95cd-8153821e830e" />

<img width="1044" height="686" alt="image" src="https://github.com/user-attachments/assets/bcc621a0-88b8-4f72-b68f-2237d4c0d331" />


## Pre-merge checklist
- [X] Code works interactively
- [X] Code contains descriptive docstrings, including context and API

# Simulations:
## Pulse Picker Rates
The count of event codes for 1 (TPG sec) interval
```
Event codes and their effective rate (sorted by count, descending):
272: 70000
273: 35000
274: 100
275: 5
```
<img width="916" height="710" alt="image" src="https://github.com/user-attachments/assets/69b95dfd-d921-4003-a98f-14519c3ae852" />

## Base Rates
### start TS1,  spacing 1 (60hz TS1 only), no goose:

<img width="781" height="504" alt="image" src="https://github.com/user-attachments/assets/92c37137-ee89-407c-a1ee-607561bfa2b9" />

### Start TS4,  spacing 1 (120hz),  goose spacing  4 ( 30hz):
<img width="736" height="470" alt="image" src="https://github.com/user-attachments/assets/6d445e2d-6eed-4a1a-a56d-88b026d00967" />

