### PR TITLE
N-in-M Goosing Sequences and Bay1

### DIFF
--- a/neh_bay1_db.json
+++ b/neh_bay1_db.json
@@ -1,0 +1,38 @@
+{
+    "Base": {
+        "_id": "Base",
+        "active": true,
+        "args": [
+            "LAS:LHN:TPR:03"
+        ],
+        "creation": "Thu Jun  17 07:54:55 2026",
+        "device_class": "pcdsdevices.tpr.TprTrigger",
+        "documentation": "Base",
+        "kwargs": {
+            "channel": 6,
+            "name": "{{name}}",
+            "timing_mode": 2
+        },
+        "last_edit": "Thu Jun  6 07:54:55 2024",
+        "name": "Base",
+        "type": "HappiItem"
+    },
+    "Goose": {
+        "_id": "Goose",
+        "active": true,
+        "args": [
+            "LAS:LHN:TPR:03"
+        ],
+        "creation": "Thu Jun  6 07:54:55 2024",
+        "device_class": "pcdsdevices.tpr.TprTrigger",
+        "documentation": "Goose",
+        "kwargs": {
+            "channel": 7,
+            "name": "{{name}}",
+            "timing_mode": 2
+        },
+        "last_edit": "Thu Jun  6 07:54:55 2024",
+        "name": "Goose",
+        "type": "HappiItem"
+    }
+}

--- a/neh_bay1_launcher.sh
+++ b/neh_bay1_launcher.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+launcher="$(realpath $0)"
+launcher_dir="$(dirname ${launcher})"
+
+cd ${launcher_dir}
+
+./launcher.sh opcpa_tpr_config/neh_bay1_config.yaml

--- a/opcpa_tpr_config/neh_bay1_config.yaml
+++ b/opcpa_tpr_config/neh_bay1_config.yaml
@@ -1,0 +1,12 @@
+# Configuration file for NEH OPCPA lasers
+
+main:
+    xpm_pv: "DAQ:FEH:XPM:0"
+    sc_meta_pv: "TPG:SYS0:1:DST04"
+    nc_meta_pv: "TODO"
+    notepad_pv: "LAS:NEH:BAY1:PVPAD"
+    engine1: "0"
+    engine2: "1"
+    title: "NEH Laser Hall Bay 3 OPCPA Rep. Rate Configuration"
+    bay: "Bay 1"
+

--- a/opcpa_tpr_config/neh_bay1_config.yaml
+++ b/opcpa_tpr_config/neh_bay1_config.yaml
@@ -7,6 +7,21 @@ main:
     notepad_pv: "LAS:NEH:BAY1:PVPAD"
     engine1: "0"
     engine2: "1"
-    title: "NEH Laser Hall Bay 3 OPCPA Rep. Rate Configuration"
+    title: "NEH Laser Hall Bay 1 Rep. Rate Configuration"
     bay: "Bay 1"
 
+    laser_database: "neh_bay1_db.json"
+    devices:
+        Goose:
+            rbvs: ["name", "eventrate", "ratemode", "seqcode", "width_setpoint", "delay_setpoint", "operation", "enable_ch_cmd"]
+            show: True
+        Base:
+            rbvs: ["name", "eventrate", "ratemode", "seqcode", "width_setpoint", "delay_setpoint", "operation", "enable_ch_cmd"]
+            show: True
+
+goose_arrival_configs:
+  cfg_goose_off:
+    desc: "Goose off"
+
+  cfg_late:
+    desc: "Late"

--- a/opcpa_tpr_config/rep_rate_config.ui
+++ b/opcpa_tpr_config/rep_rate_config.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>279</width>
-    <height>443</height>
+    <height>482</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -50,6 +50,12 @@
      </item>
      <item row="1" column="1">
       <widget class="PyDMLabel" name="on_time_ec_rbv">
+       <property name="maximumSize">
+        <size>
+         <width>100</width>
+         <height>16777215</height>
+        </size>
+       </property>
        <property name="toolTip">
         <string/>
        </property>
@@ -60,6 +66,12 @@
      </item>
      <item row="2" column="1">
       <widget class="PyDMLabel" name="off_time_ec_rbv">
+       <property name="maximumSize">
+        <size>
+         <width>100</width>
+         <height>16777215</height>
+        </size>
+       </property>
        <property name="toolTip">
         <string/>
        </property>
@@ -70,6 +82,12 @@
      </item>
      <item row="2" column="2">
       <widget class="PyDMLabel" name="off_time_rate_rbv">
+       <property name="maximumSize">
+        <size>
+         <width>100</width>
+         <height>16777215</height>
+        </size>
+       </property>
        <property name="toolTip">
         <string/>
        </property>
@@ -101,6 +119,12 @@
      </item>
      <item row="1" column="2">
       <widget class="PyDMLabel" name="on_time_rate_rbv">
+       <property name="maximumSize">
+        <size>
+         <width>100</width>
+         <height>16777215</height>
+        </size>
+       </property>
        <property name="toolTip">
         <string/>
        </property>
@@ -118,6 +142,12 @@
      </item>
      <item row="3" column="1">
       <widget class="PyDMLabel" name="all_shots_ec_rbv">
+       <property name="maximumSize">
+        <size>
+         <width>100</width>
+         <height>16777215</height>
+        </size>
+       </property>
        <property name="toolTip">
         <string/>
        </property>
@@ -128,6 +158,12 @@
      </item>
      <item row="3" column="2">
       <widget class="PyDMLabel" name="all_shots_rate_rbv">
+       <property name="maximumSize">
+        <size>
+         <width>100</width>
+         <height>16777215</height>
+        </size>
+       </property>
        <property name="toolTip">
         <string/>
        </property>
@@ -156,6 +192,27 @@
       <property name="bottomMargin">
        <number>0</number>
       </property>
+      <item>
+       <widget class="QLabel" name="nc_timeslot_label">
+        <property name="text">
+         <string>Start Timeslot</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QComboBox" name="nc_timeslot_selector">
+        <item>
+         <property name="text">
+          <string>TS1</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>TS4</string>
+         </property>
+        </item>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>
@@ -230,6 +287,12 @@
           </item>
           <item>
            <widget class="PyDMLabel" name="sc_bucket_rbv">
+            <property name="maximumSize">
+             <size>
+              <width>50</width>
+              <height>16777215</height>
+             </size>
+            </property>
             <property name="toolTip">
              <string/>
             </property>
@@ -336,6 +399,12 @@
           </item>
           <item>
            <widget class="PyDMLabel" name="nc_bucket_rbv">
+            <property name="maximumSize">
+             <size>
+              <width>50</width>
+              <height>16777215</height>
+             </size>
+            </property>
             <property name="toolTip">
              <string/>
             </property>
@@ -393,28 +462,6 @@
      </item>
      <item>
       <widget class="QComboBox" name="goose_rate_box"/>
-     </item>
-     <item>
-      <widget class="QLabel" name="goose_rate_label_3">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>50</width>
-         <height>16777215</height>
-        </size>
-       </property>
-       <property name="text">
-        <string>(Rate)</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-       </property>
-      </widget>
      </item>
     </layout>
    </item>
@@ -514,6 +561,12 @@
          <horstretch>0</horstretch>
          <verstretch>0</verstretch>
         </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>120</width>
+         <height>16777215</height>
+        </size>
        </property>
        <property name="toolTip">
         <string/>

--- a/opcpa_tpr_config/rep_rate_config.ui
+++ b/opcpa_tpr_config/rep_rate_config.ui
@@ -15,7 +15,7 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <widget class="QLabel" name="rep_rate_label">
+    <widget class="QLabel" name="title">
      <property name="font">
       <font>
        <weight>75</weight>
@@ -156,27 +156,6 @@
       <property name="bottomMargin">
        <number>0</number>
       </property>
-      <item>
-       <widget class="QLabel" name="nc_timeslot_label">
-        <property name="text">
-         <string>Start Timeslot</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QComboBox" name="nc_timeslot_selector">
-        <item>
-         <property name="text">
-          <string>TS1</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>TS4</string>
-         </property>
-        </item>
-       </widget>
-      </item>
      </layout>
     </widget>
    </item>
@@ -325,7 +304,7 @@
           <item>
            <widget class="QLabel" name="nc_start_bucket_label">
             <property name="text">
-             <string>AC -Offset (0 to 13)</string>
+             <string>35kH Offset (0)</string>
             </property>
            </widget>
           </item>
@@ -408,12 +387,94 @@
      <item>
       <widget class="QLabel" name="goose_rate_label">
        <property name="text">
-        <string>Goose Rate</string>
+        <string>Goose Loop Rate</string>
        </property>
       </widget>
      </item>
      <item>
       <widget class="QComboBox" name="goose_rate_box"/>
+     </item>
+     <item>
+      <widget class="QLabel" name="goose_rate_label_3">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>50</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>(Rate)</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="goose_rate_layout_2">
+     <item>
+      <widget class="QLabel" name="goose_len_label">
+       <property name="text">
+        <string>Goose Length</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="goose_len_input">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="inputMask">
+        <string>9</string>
+       </property>
+       <property name="text">
+        <string>1</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="goose_rate_layout_4">
+     <item>
+      <widget class="QLabel" name="goose_start_label">
+       <property name="text">
+        <string>Goose Start Offset</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="goose_start_input">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="inputMask">
+        <string>9</string>
+       </property>
+       <property name="text">
+        <string>1</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+      </widget>
      </item>
     </layout>
    </item>

--- a/opcpa_tpr_config/tests/test_gui.sh
+++ b/opcpa_tpr_config/tests/test_gui.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+launcher="$(realpath $0)"
+launcher_dir="$(dirname ${launcher})"
+
+cd ${launcher_dir}
+
+./launcher.sh opcpa_tpr_config/tests/test_gui.yaml

--- a/opcpa_tpr_config/tests/test_gui.sh
+++ b/opcpa_tpr_config/tests/test_gui.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-launcher="$(realpath $0)"
-launcher_dir="$(dirname ${launcher})"
+script_dir="$(dirname "$(realpath "$0")")"
+project_root="${script_dir}/../.."
 
-cd ${launcher_dir}
+cd "${project_root}"
 
 ./launcher.sh opcpa_tpr_config/tests/test_gui.yaml

--- a/opcpa_tpr_config/tests/test_gui.yaml
+++ b/opcpa_tpr_config/tests/test_gui.yaml
@@ -1,0 +1,11 @@
+# Configuration file for testing the gui
+
+main:
+    sc_meta_pv: "TPG:SYS0:1:DST04"
+    nc_meta_pv: "TODO"
+    notepad_pv: "LAS:NEH:TEST:PVPAD"
+    engine1: "0"
+    engine2: "1"
+    title: "Test OPCPA Rep. Rate Configuration"
+    bay: "Bay SIM"
+

--- a/opcpa_tpr_config/tests/test_plot.py
+++ b/opcpa_tpr_config/tests/test_plot.py
@@ -1,0 +1,101 @@
+"""Plotting utilities for XPM sequence visualization."""
+
+from __future__ import annotations
+
+import matplotlib.pyplot as plt
+import numpy as np
+from PyQt5 import QtWidgets
+
+from opcpa_tpr_config.tests.test_sequences import simulate_laser_case
+
+
+class SequencePlotter:
+    """Collects multiple sequence traces and plots them overlaid.
+
+    Overlapping y values are offset slightly so all traces remain visible.
+    """
+
+    def __init__(self, is_sc: bool, y_offset: float = 0.25):
+        self._traces: list[tuple[np.ndarray, np.ndarray, str, str]] = []
+        self._y_offset = y_offset
+        self._is_sc = is_sc
+
+    def add(self, data: tuple, label: str, color: str = "blue"):
+        """Add a sequence trace to be plotted."""
+        xdata = np.array(data[0], dtype=float) + 1
+        ydata = np.array(data[1], dtype=float)
+        self._traces.append((xdata, ydata, label, color))
+
+    def show(self, title: str = "Sequence Comparison"):
+        """Display all collected traces on a single plot."""
+        if not self._traces:
+            return
+
+        fig, ax = plt.subplots(figsize=(14, 6))
+
+        # Apply incremental y-offset per trace so overlapping points separate
+        for idx, (xdata, ydata, label, color) in enumerate(self._traces):
+            offset = idx * self._y_offset
+            ax.bar(
+                xdata, height=0.1, bottom=ydata-offset + 0.2,
+                width=0.4, label=label, color=color, alpha=0.7,
+            )
+
+        # Clock gridlines: 120Hz (period=3 in AC frames) or 35kHz (period=26 in 910k frames)
+        all_x = np.concatenate([t[0] for t in self._traces])
+        x_min, x_max = all_x.min(), all_x.max()
+        if self._is_sc:
+            clock_period = 910000 / 35000  # 26 frames per 35kHz tick
+        else:
+            clock_period = 3  # 360/120 = 3 AC frames per 120Hz tick
+        ticks = np.arange(
+            clock_period * np.ceil(x_min / clock_period),
+            x_max + 1,
+            clock_period,
+        )
+        for t in ticks:
+            ax.axvline(t, color="gray", alpha=0.15, linewidth=0.5)
+
+        ax.set_xlabel("Frame")
+        ax.set_ylabel("Event Code")
+        ax.set_title(title)
+        ax.legend(fontsize="small", loc="upper right")
+        plt.tight_layout()
+        plt.show()
+
+
+def plot_case(
+    plotter: SequencePlotter,
+    label: str,
+    color: str,
+    is_sc: bool,
+    rate: int,
+    goose_rate: int | None,
+    goose_len: int = 1,
+    goose_start: int = 1,
+    start_ts1: bool = True,
+):
+    """Simulate a case and add it to the plotter."""
+    data, _ = simulate_laser_case(
+        is_sc=is_sc,
+        rate=rate,
+        goose_rate=goose_rate,
+        goose_len=goose_len,
+        goose_start=goose_start,
+        start_ts1=start_ts1,
+    )
+    plotter.add(data, label=label, color=color)
+
+
+if __name__ == "__main__":
+    # Collect cases into one plot
+    plotter = SequencePlotter(is_sc=False, y_offset=0.15)
+    plot_case(plotter, "120Hz no goose", "blue",
+             is_sc=False, rate=120, goose_rate=None)
+    plot_case(plotter, "120Hz goose 24Hz, start 2", "red",
+             is_sc=False, rate=120, goose_rate=24, goose_start=2)
+    plot_case(plotter, "60Hz goose 10Hz", "black",
+             is_sc=False, rate=60, goose_rate=10, goose_start=1)
+    plot_case(plotter, "120Hz goose 24Hz len=3", "green",
+             is_sc=False, rate=120, goose_rate=24, goose_len=3)
+    plotter.show(title="NC 120Hz Sequence Comparison")

--- a/opcpa_tpr_config/tests/test_sequences.py
+++ b/opcpa_tpr_config/tests/test_sequences.py
@@ -1,9 +1,6 @@
 """ Tests for XPM sequence generation"""
 
-from PyQt5 import QtCore, QtGui, QtWidgets
-import pyqtgraph as pg
 import numpy as np
-import argparse
 import psdaq.seq.seq
 from psdaq.seq.globals import *
 from psdaq.seq.seqplot import *
@@ -11,25 +8,6 @@ from pprint import pprint
 
 from opcpa_tpr_config import xpm_prog
 
-
-def plot_seq(seq_data: tuple):
-    """ Plots the sequence waveform """
-    app = QtWidgets.QApplication([])
-    plot = PatternWaveform()
-    
-    plot.add("Simulation", *seq_data)
-
-    MainWindow = QtWidgets.QMainWindow()
-    centralWidget = QtWidgets.QWidget(MainWindow)
-    vb = QtWidgets.QVBoxLayout()
-    vb.addWidget(plot.gl)
-    centralWidget.setLayout(vb)
-    MainWindow.setCentralWidget(centralWidget)
-    MainWindow.updateGeometry()
-    MainWindow.show()
-
-    app.exec_()
-    
 
 def simulate_sequence(title, instrset, descset, stop=910001, engine=0, acmode=False):
     """
@@ -47,18 +25,19 @@ def simulate_sequence(title, instrset, descset, stop=910001, engine=0, acmode=Fa
         the number of frames to simulate
     acmode : bool, optional
         if following Fixed rate or AC marker  (won't simulate both)
-    
+
     Returns
     -------
     the sequence object after execution
-        
+
     """
-    seq = SeqUser(start=0,stop=stop,acmode=acmode)
-    seq.execute(title,instrset,descset)
-    ydata = np.array(seq.ydata)+int(engine)*4+272
+    seq = SeqUser(start=0, stop=stop, acmode=acmode)
+    seq.execute(title, instrset, descset)
+    ydata = np.array(seq.ydata) + int(engine) * 4 + 272
     return (seq.xdata, ydata)
 
-def sequence_stats(data:tuple, event_defs=None):
+
+def sequence_stats(data: tuple, event_defs=None):
     """
     Gives basic stats about the generated sequence to confirm the
     correct number of triggers are generated.
@@ -72,19 +51,19 @@ def sequence_stats(data:tuple, event_defs=None):
     unique_codes, counts = np.unique(event_codes, return_counts=True)
     sorted_indices = np.argsort(unique_codes)
     unique_codes = unique_codes[sorted_indices]
-    counts = counts[sorted_indices] 
+    counts = counts[sorted_indices]
 
-    #if event_defs is a list, assume names are given in order
-    if event_defs is not None and isinstance(event_defs,list):
+    # if event_defs is a list, assume names are given in order
+    if event_defs is not None and isinstance(event_defs, list):
         event_dict = {}
-        for event_code, event_name in zip(unique_codes, event_defs): 
+        for event_code, event_name in zip(unique_codes, event_defs):
             event_dict[int(event_code)] = event_name
         event_defs = event_dict
 
-    # generate a dict for each event code, add counts and event name 
+    # generate a dict for each event code, add counts and event name
     for value, count in zip(unique_codes, counts):
         event_name = "NA" if event_defs is None else event_defs[value]
-        event_code_stats[int(value)] = {"count":int(count), "event_name":event_name}
+        event_code_stats[int(value)] = {"count": int(count), "event_name": event_name}
 
     # get first instance of each marker, add to dict
     for xi, yi in zip(frame_number, unique_codes):
@@ -95,58 +74,133 @@ def sequence_stats(data:tuple, event_defs=None):
     return event_code_stats
 
 
-def test_nc_base_sequences():
+def test_base_sequences():
     """ Test that the NC Base sequences are simulated properly."""
-    base_sequence_instrset = xpm_prog.make_base_sequence_nc() 
+    seqdesc, instrset = xpm_prog.build_base_sequence(
+        is_sc=False, offset=0, bay="Test"
+    )
     event_names = ['70kH', '35kH', '100H', '5H']
     data = simulate_sequence(
         "NC Base Sequence", 
-        base_sequence_instrset,
+        instrset,
         event_names,
         stop=910000,
         engine=0,
         acmode=False
         )
     pprint(sequence_stats(data, event_names))
-    # plot_seq(data)
 
-def test_nc_sequences():
-    """ 
-    Test base rate trigger for the laser
-    Note: the initial ACRateSync is not simulated here, 
-    as that is not a feature of the simulation library I am using
+def filter_second_period(data: tuple, period: int) -> tuple:
+    """Filter simulation data to only include the 2nd period (frames >= period)."""
+    xdata, ydata = np.array(data[0]), np.array(data[1])
+    mask = xdata >= period -1
+    return (xdata[mask], ydata[mask])
+
+
+def simulate_laser_case(
+    is_sc: bool,
+    rate: int,
+    goose_rate: int | None,
+    goose_len: int = 1,
+    goose_start: int = 1,
+    start_ts1: bool = True,
+    assert_check: bool = False
+) -> tuple:
+    """Build, simulate 2 periods, and report stats for the 2nd period.
+
+    The 1st period is discarded to skip initial offset part of the sequence.
+    Asserts that event counts in the 2nd period match expected rates.
+    Returns (data, stats) for the 2nd period.
     """
-    from opcpa_tpr_config import xpm_prog
-
-    #some definitions
     event_names = ["On Time", "Goose", "All Shots"]
+    clock = 910000 if is_sc else 360
 
-    #iterate through all rates and offsets
-    all_rates =  xpm_prog.make_possible_rates(xpm_prog.nc_factors)
-    for rate in all_rates:
-        base_div = 120//rate
-        goose_rates =  xpm_prog.allowed_goose_rates(rate,all_rates)
-        goose_rates.append(None) # also check no goose
-        for goose_rate in goose_rates:
-            if goose_rate is not None:
-                goose_div = 120//goose_rate
-            else:
-                goose_div = None
-            for start_ts1 in [True, False]:
-                nc_sequence_instrset = xpm_prog.make_sequence_nc(base_div, start_ts1, goose_div) 
-                data = simulate_sequence("NC Sequence", nc_sequence_instrset, event_names , stop=361, engine=0, acmode=True)
-                print(f"\nNC Sequence Rate: {rate} Hz, Goose Rate: {goose_rate}  TS1_start: {start_ts1}")
-                pprint(sequence_stats(data, event_names))
-                #plot select sequences if here if needed
-                if rate == 120 and goose_rate is None:
-                    plot_seq(data)
+    seqdesc, instrset = xpm_prog.build_laser_sequence(
+        is_sc=is_sc,
+        base_rate=rate,
+        goose_rate=goose_rate,
+        goose_enabled=goose_rate is not None,
+        offset=0,
+        start_ts1=start_ts1,
+        goose_len=goose_len,
+        goose_start=goose_start,
+        bay="Test",
+    )
+
+    # Simulate 2 full periods
+    raw_data = simulate_sequence(
+        "SC Sequence" if is_sc else "NC Sequence",
+        instrset, event_names,
+        stop=(2 * clock) - 1, engine=0, acmode=(not is_sc),
+    )
+
+    # Analyze only the 2nd period (skip startup transient)
+    data = filter_second_period(raw_data, clock)
+    stats = sequence_stats(data, event_names)
+
+    mode = "SC" if is_sc else "NC"
+    timestamp_start = f"  TS1_start: {start_ts1}" if not is_sc else ""
+    goose_start_msg = f"  Goose Start: {goose_start}" if not is_sc else ""
+    goose_len_msg = f"  Goose_len: {goose_len}" if goose_rate is not None else ""
+    print(f"\n{mode} Rate: {rate} Hz, Goose: {goose_rate}{timestamp_start}{goose_len_msg}{goose_start_msg}")
+    pprint(stats)
+
+    if assert_check:
+        ontime = stats[272]["count"]
+        all_shots = stats[274]["count"]
+
+        if rate != all_shots:
+            print(f"ERROR: Simulated rate {all_shots}, Expected Rate {rate}")
+
+        #check goose shots/:
+        if goose_rate is not None:
+            exp_goose_len = min(rate//goose_rate - 1 , goose_len)
+            expected = goose_rate * exp_goose_len
+            assert 273 in stats, f"ERROR: no goose shots detected, Expected goose rate{expected}"
+            goose = stats[273]["count"]
+            # TODO: come up with a reliable way to assert number of goose, 
+            # since sequences can start at different locations, this is not strait forward
+            # assert abs(goose - expected) <= 1, f"ERROR: Simulated goose {goose}, Expected Rate {expected}"
+        else:
+            if 273 in stats:
+                goose = stats[273]["count"]
+                raise AssertionError(f"ERROR: goose shots fired when disabled. {goose}")
 
 
+    return data, stats
+
+
+def test_all_sequences(
+    rate: int,
+    is_sc: bool = True,
+    goose_starts: list[int] | None = None,
+    goose_lens: list[int] | None = None,
+):
+    """Test sequences across all rate / goose / goose_len combos."""
+    if goose_starts is None:
+        goose_starts = [1, 2, 3]
+    if goose_lens is None:
+        goose_lens = [1, 2, 3, 4]
+
+    factors = xpm_prog.sc_factors if is_sc else xpm_prog.nc_factors
+    all_rates = xpm_prog.make_possible_rates(factors)
+
+    goose_rates = xpm_prog.allowed_goose_rates(rate, all_rates)
+    goose_rates.append(None)
+    for goose_rate in goose_rates:
+        for goose_start in goose_starts:
+            for goose_len in goose_lens:
+                simulate_laser_case(
+                    is_sc=is_sc,
+                    rate=rate,
+                    goose_rate=goose_rate,
+                    goose_len=goose_len,
+                    goose_start=goose_start,
+                    assert_check=True
+                )
 
 if __name__ == "__main__":
-    test_nc_base_sequences()
-    test_nc_sequences()
-    #print some choice AC sequences
+    test_base_sequences()
+    test_all_sequences(1000, is_sc=True)
+    test_all_sequences(120, is_sc=False)
 
-
-    

--- a/opcpa_tpr_config/tests/test_sequences.py
+++ b/opcpa_tpr_config/tests/test_sequences.py
@@ -122,7 +122,7 @@ def test_nc_sequences():
     event_names = ["On Time", "Goose", "All Shots"]
 
     #iterate through all rates and offsets
-    all_rates =  xpm_prog.make_base_rates(xpm_prog.nc_factors)
+    all_rates =  xpm_prog.make_possible_rates(xpm_prog.nc_factors)
     for rate in all_rates:
         base_div = 120//rate
         goose_rates =  xpm_prog.allowed_goose_rates(rate,all_rates)

--- a/opcpa_tpr_config/user_config.py
+++ b/opcpa_tpr_config/user_config.py
@@ -37,10 +37,16 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    log_level = logging.DEBUG if args.debug else logging.INFO
     logging.basicConfig(
-        level=log_level,
+        level=logging.WARNING,
         format="%(asctime)s %(name)s [%(levelname)s] %(message)s",
     )
+    log_level = logging.DEBUG if args.debug else logging.INFO
+    loggers = [
+        logging.getLogger("widgets"),
+        logging.getLogger("xpm_prog")
+    ]
+    for logger in loggers:
+        logger.setLevel(log_level)
 
     main(config=args.config)

--- a/opcpa_tpr_config/user_config.py
+++ b/opcpa_tpr_config/user_config.py
@@ -9,7 +9,6 @@ logger = logging.getLogger(__name__)
 
 def main(
     config: str = "",
-    debug: bool = False,
     stylesheet: Optional[str] = None
 ) -> None:
     """Launch the ``Rep. rate user config UI``."""
@@ -18,7 +17,7 @@ def main(
         app = QtWidgets.QApplication([])
 
     try:
-        widget = UserConfigDisplay(config=config, debug=debug)
+        widget = UserConfigDisplay(config=config)
         widget.show()
         app.exec_()
     except Exception:
@@ -34,8 +33,14 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "-d", "--debug", action='store_true',
-        help="Print debug information, do not change settings"
+        help="Enable debug-level logging"
     )
     args = parser.parse_args()
 
-    main(config=args.config, debug=args.debug)
+    log_level = logging.DEBUG if args.debug else logging.INFO
+    logging.basicConfig(
+        level=log_level,
+        format="%(asctime)s %(name)s [%(levelname)s] %(message)s",
+    )
+
+    main(config=args.config)

--- a/opcpa_tpr_config/widgets.py
+++ b/opcpa_tpr_config/widgets.py
@@ -20,7 +20,6 @@ from xpm_prog import (allowed_goose_rates, sc_factors, nc_factors,
 
 logger = logging.getLogger(__name__)
 
-
 def read_config(config_file):
     """
     Read in the config file for the screen.
@@ -40,22 +39,18 @@ class NCMetadataDisplay(Display):
     ):
         super().__init__(parent, **kwargs)
 
-    def setup_display(self, config, debug):
+    def setup_display(self, config):
         """
         Run the things we would run during init but can't because I can't
         figure out how to pass variables to sub-displays at init....
         """
-        self._debug = debug
-
         self._config = read_config(config)
         if self._config is None:
             raise ValueError(f"Could not read config file {config}")
 
-        if self._debug:
-            print(f"Read configuration file: {config}")
-            cfg_keys = self._config.keys()
-            print(f"Configuration sections: {cfg_keys}")
-            print(self._config)
+        logger.info(f"Read configuration file: {config}")
+        logger.debug(f"Configuration sections: {self._config.keys()}")
+        logger.debug(f"{self._config}")
 
         self.update_pvs()
 
@@ -66,8 +61,7 @@ class NCMetadataDisplay(Display):
         #  metadata
         nc_base = self._config['main']['nc_meta_pv']
 
-        if self._debug:
-            print(f"SC metadata base PV: {nc_base}")
+        logger.debug(f"NC metadata base PV: {nc_base}")
 
         # TODO: find relevant NC metadata PVs to display
 
@@ -93,22 +87,18 @@ class SCMetadataDisplay(Display):
     ):
         super().__init__(parent, **kwargs)
 
-    def setup_display(self, config, debug):
+    def setup_display(self, config):
         """
         Run the things we would run during init but can't because I can't
         figure out how to pass variables to sub-displays at init....
         """
-        self._debug = debug
-
         self._config = read_config(config)
         if self._config is None:
             raise ValueError(f"Could not read config file {config}")
 
-        if self._debug:
-            print(f"Read configuration file: {config}")
-            cfg_keys = self._config.keys()
-            print(f"Configuration sections: {cfg_keys}")
-            print(self._config)
+        logger.info(f"Read configuration file: {config}")
+        logger.debug(f"Configuration sections: {self._config.keys()}")
+        logger.debug(f"{self._config}")
 
         self.update_pvs()
 
@@ -119,8 +109,7 @@ class SCMetadataDisplay(Display):
         # SC metadata
         sc_base = self._config['main']['sc_meta_pv']
 
-        if self._debug:
-            print(f"SC metadata base PV: {sc_base}")
+        logger.debug(f"SC metadata base PV: {sc_base}"))
 
         self.pattern_name_rbv.set_channel(f"ca://{sc_base}:NAME")
         self.rate_rbv.set_channel(f"ca://{sc_base}:RATE_RBV")
@@ -189,13 +178,11 @@ class LaserConfigDisplay(Display):
     ):
         super().__init__(parent, **kwargs)
 
-    def setup_display(self, config, debug):
+    def setup_display(self, config):
         """
         Run the things we would run during init but can't because I can't
         figure out how to pass variables to sub-displays at init....
         """
-        self._debug = debug
-
         self._config = read_config(config)
         if self._config is None:
             raise ValueError(f"Could not read config file {config}")
@@ -204,11 +191,9 @@ class LaserConfigDisplay(Display):
         self._engine1 = int(self._config['main']['engine1'])
         self._engine2 = int(self._config['main']['engine2'])
 
-        if self._debug:
-            print(f"Read configuration file: {config}")
-            cfg_keys = self._config.keys()
-            print(f"Configuration sections: {cfg_keys}")
-            print(self._config)
+        logger.info(f"Read configuration file: {config}")
+        logger.debug(f"Configuration sections: {self._config.keys()}")
+        logger.debug(f"{self._config}")
 
         self.status_label.setText("Status: Idle")
         # Hiding this because the status doesn't work well without threading
@@ -298,13 +283,12 @@ class LaserConfigDisplay(Display):
         }
         ]'''
 
-        if self._debug:
-            print(f"Engine 1: {self._engine1}")
-            print(f"Engine 2: {self._engine2}")
-            print(f"On time EC: {self._on_time}")
-            print(f"Off time EC: {self._off_time}")
-            print(f"On time index: {on_time_idx}")
-            print(f"Off time index: {off_time_idx}")
+        logger.debug(f"Engine 1: {self._engine1}")
+        logger.debug(f"Engine 2: {self._engine2}")
+        logger.debug(f"On time EC: {self._on_time}")
+        logger.debug(f"Off time EC: {self._off_time}")
+        logger.debug(f"On time index: {on_time_idx}")
+        logger.debug(f"Off time index: {off_time_idx}")
 
     def ui_filename(self):
         return "rep_rate_config.ui"
@@ -339,8 +323,7 @@ class LaserConfigDisplay(Display):
         # always select the highest rate when switching menus
         self.total_rate_box.setCurrentIndex(self.total_rate_box.count() - 1)
 
-        if self._debug:
-            print(f"Allowed base rates: {self._base_rates}")
+        logger.debug(f"Allowed base rates: {self._base_rates}")
 
     @property
     def base_rate(self):
@@ -373,9 +356,8 @@ class LaserConfigDisplay(Display):
             self.goose_start_input.setText("1")
             for rate in goose_rates:
                 self.goose_rate_box.addItem(str(rate))
-            if self._debug:
-                print(f"Requested base rate: {rate}")
-                print(f"Allowed goose rates: {goose_rates}")
+            logger.debug(f"Requested base rate: {rate}")
+            logger.debug(f"Allowed goose rates: {goose_rates}")
 
     @property
     def goose_rate(self):
@@ -384,8 +366,7 @@ class LaserConfigDisplay(Display):
     def update_goose_arrival(self):
         cfgs = self._config['goose_arrival_configs']
         if cfgs is not None:
-            if self._debug:
-                print(f"Goose arrival configs: {cfgs}")
+            logger.debug(f"Goose arrival configs: {cfgs}")
             for name, cfg in cfgs.items():
                 text = cfg['desc']
                 cfg.pop('desc', None)
@@ -472,9 +453,7 @@ class ExpertDisplay(Display):
             path.dirname(path.realpath(__file__)), self.ui_filename()
         )
 
-    def setup_display(self, config, debug):
-
-        self._debug = debug
+    def setup_display(self, config):
 
         self._config = read_config(config)
         if self._config is None:
@@ -661,20 +640,17 @@ class UserConfigDisplay(Display):
         self,
         parent=None,
         config: str = "",
-        debug: bool = False,
         **kwargs
     ):
         super().__init__(parent, **kwargs)
 
-        self.laser_config_widget.setup_display(config, debug)
+        self.laser_config_widget.setup_display(config)
 
-        self.sc_metadata_widget.setup_display(config, debug)
+        self.sc_metadata_widget.setup_display(config)
 
-        self.nc_metadata_widget.setup_display(config, debug)
+        self.nc_metadata_widget.setup_display(config)
 
-        self.expert_display_widget.setup_display(config, debug)
-
-        self._debug = debug
+        self.expert_display_widget.setup_display(config)
 
         self._config = read_config(config)
         if self._config is None:
@@ -752,14 +728,6 @@ class UserConfigDisplay(Display):
         
 
     @property
-    def debug(self):
-        return self._debug
-
-    @debug.setter
-    def debug(self, value):
-        self._debug = bool(value)
-
-    @property
     def expert_mode(self):
         return self.expert_checkbox.isChecked()
     
@@ -826,14 +794,12 @@ class UserConfigDisplay(Display):
                     if devclass == "ophyd.signal.EpicsSignal":
                         if 'val' in config.keys():
                             instance.put(config['val'])
-                            if self._debug:
-                                print(f"Put {device} {config['val']}")
+                            logger.info(f"Put {device} {config['val']}")
                         else:
                             raise Exception("Missing 'val' for EpicsSignal")
                     else:
                         instance.configure(config)
-                        if self._debug:
-                            print(f"Configure {device} {config}")
+                        logger.info(f"Configure {device} {config}")
 
     def calc_tic_averaging(self, total_rate):
         """
@@ -860,17 +826,16 @@ class UserConfigDisplay(Display):
         else:
             goose_div = None
 
-        if self._debug:
-            print("Applying laser rates")
-            print(f"Base rate: {self.laser_config_widget.base_rate}")
-            print(f"Goose rate: {self.laser_config_widget.goose_rate}")
-            print(f"Goose arrival: {self.laser_config_widget.arrival_config}")
-            print(f"Base div: {base_div}")
-            print(f"Goose div: {goose_div}")
-            print(f"Offset: {self.offset}")
+        logger.info("Applying laser rates")
+        logger.info(f"Base rate: {self.laser_config_widget.base_rate}")
+        logger.info(f"Goose rate: {self.laser_config_widget.goose_rate}")
+        logger.debug(f"Goose arrival: {self.laser_config_widget.arrival_config}")
+        logger.debug(f"Base div: {base_div}")
+        logger.debug(f"Goose div: {goose_div}")
+        logger.info(f"Offset: {self.offset}")
 
         if self.is_superconducting:
-            instrset = make_sequence_sc(base_div, goose_div, self.offset, self._debug)
+            instrset = make_sequence_sc(base_div, goose_div, self.offset)
         else:
             instrset = make_sequence_nc(base_div, self.laser_config_widget.start_ts1, goose_div) 
 
@@ -885,9 +850,8 @@ class UserConfigDisplay(Display):
         Generate and apply the XPM configuration for the "base" laser rates
         that should always be available.
         """
-        if self._debug:
-            print("Applying base rates")
-            print(f"Offset: {self.offset}")
+        logger.info("Applying base rates")
+        logger.info(f"Offset: {self.offset}")
 
         bay = self._config['main']['bay']
         seqdesc = {0: f"{bay} 71.4kHz", 1: f"{bay} 35.7kHz", 2: f"{bay} 102Hz",

--- a/opcpa_tpr_config/widgets.py
+++ b/opcpa_tpr_config/widgets.py
@@ -15,7 +15,7 @@ from qtpy import QtWidgets
 from xpm_prog import (allowed_goose_rates, sc_factors, nc_factors,
                 make_possible_rates,
                 make_base_sequence, make_sequence_sc,
-                make_sequence_nc
+                make_sequence_nc, validate_goose_len
                 )
 
 logger = logging.getLogger(__name__)
@@ -170,8 +170,14 @@ class LaserConfigDisplay(Display):
     total_rate_label: QtWidgets.QLabel
     goose_rate_box: QtWidgets.QComboBox
     goose_rate_label: QtWidgets.QLabel
+    goose_effective_rate_label: QtWidgets.QLabel
     goose_arrival_box: QtWidgets.QComboBox
     goose_arrival_label: QtWidgets.QLabel
+    goose_start_label: QtWidgets.QLabel
+    goose_start_input: QtWidgets.QLineEdit
+    goose_len_label: QtWidgets.QLabel
+    goose_len_input: QtWidgets.QLineEdit
+
 
     apply_button: pydm_widgets.PyDMPushButton
     status_label: QtWidgets.QLabel
@@ -231,6 +237,9 @@ class LaserConfigDisplay(Display):
         self.sc_bucket_control_box.currentTextChanged.connect(
             self.update_bucket_control_vis
         )
+
+        self.goose_len_input.editingFinished.connect(self._validate_goose_len)
+
 
     def update_pvs(self):
         """
@@ -308,8 +317,10 @@ class LaserConfigDisplay(Display):
     def update_base_rates(self, is_superconducting):
         if is_superconducting:
             factors = sc_factors
+            self._clock_rate = 910000
         else:
             factors = nc_factors
+            self._clock_rate = 120
         
         self._base_rates = make_possible_rates(factors)
         # Restrict allowed rates to > 1kHz for sc and >5hz for NC, but keep all rates in
@@ -346,6 +357,10 @@ class LaserConfigDisplay(Display):
         """
         self.goose_rate_box.setVisible(self.goose_enabled)
         self.goose_rate_label.setVisible(self.goose_enabled)
+        self.goose_len_label.setVisible(self.goose_enabled)
+        self.goose_len_input.setVisible(self.goose_enabled)
+        self.goose_start_label.setVisible(self.goose_enabled)
+        self.goose_start_input.setVisible(self.goose_enabled)
 
     def update_goose_rates(self):
         if self._base_rates is not None and self.base_rate is not None:
@@ -354,6 +369,8 @@ class LaserConfigDisplay(Display):
                 self._base_rates
             )
             self.goose_rate_box.clear()
+            self.goose_len_input.setText("1")
+            self.goose_start_input.setText("1")
             for rate in goose_rates:
                 self.goose_rate_box.addItem(str(rate))
             if self._debug:
@@ -417,6 +434,19 @@ class LaserConfigDisplay(Display):
     @property
     def nc_manual_bucket(self):
         return int(self.nc_bucket_edit.text())
+
+    def _validate_goose_len(self):
+        """Clamp goose_len_input to valid range via validate_goose_len."""
+        if self.base_rate is None or not self.goose_enabled:
+            return
+        try:
+            goose_len = int(self.goose_len_input.text())
+        except ValueError:
+            goose_len = 1
+        base_div = self._clock_rate // self.base_rate
+        goose_div = self._clock_rate // self.goose_rate
+        valid = validate_goose_len(base_div, goose_div, goose_len)
+        self.goose_len_input.setText(str(valid))
 
 
 class ExpertDisplay(Display):
@@ -651,9 +681,11 @@ class UserConfigDisplay(Display):
             raise ValueError(f"Could not read config file {config}")
 
         if self._config is not None:
-            self._db = happi.Client(
-                path=self._config['main']['laser_database']
-            )
+            db_path = self._config.get('main', {}).get('laser_database')
+            if db_path is None:
+                self._db = None
+            else:
+                self._db = happi.Client(path=db_path)
 
         self._engine1 = int(self._config['main']['engine1'])
         self._engine2 = int(self._config['main']['engine2'])
@@ -728,15 +760,6 @@ class UserConfigDisplay(Display):
         self._debug = bool(value)
 
     @property
-    def db(self):
-        if self.config is not None:
-            self._db = happi.Client(
-                path=self._config['main']['laser_database']
-            )
-            return self._db
-        return None
-
-    @property
     def expert_mode(self):
         return self.expert_checkbox.isChecked()
     
@@ -780,6 +803,9 @@ class UserConfigDisplay(Display):
         sig.put(t)
 
     def apply_device_config(self):
+        if self._db is None:
+            #no devices need configuration
+            return
         supported_devices = [
             "pcdsdevices.tpr.TprTrigger",
             "ophyd.signal.EpicsSignal",
@@ -907,6 +933,8 @@ class UserConfigDisplay(Display):
         prevents the TIC measurement from getting messed up during
         configuration.
         """
+        if self._db is None:
+            return
         if enable:
             conf = {'enable_trg_cmd': 'Enabled', 'enable_ch_cmd': 'Enabled'}
         else:

--- a/opcpa_tpr_config/widgets.py
+++ b/opcpa_tpr_config/widgets.py
@@ -109,7 +109,7 @@ class SCMetadataDisplay(Display):
         # SC metadata
         sc_base = self._config['main']['sc_meta_pv']
 
-        logger.debug(f"SC metadata base PV: {sc_base}"))
+        logger.debug(f"SC metadata base PV: {sc_base}")
 
         self.pattern_name_rbv.set_channel(f"ca://{sc_base}:NAME")
         self.rate_rbv.set_channel(f"ca://{sc_base}:RATE_RBV")

--- a/opcpa_tpr_config/widgets.py
+++ b/opcpa_tpr_config/widgets.py
@@ -229,7 +229,7 @@ class LaserConfigDisplay(Display):
         Modify RBV widgets to use the PV(s) specified in the config file.
         """
         # Event code data
-        xpm_pv = self._config['main']['xpm_pv']
+        xpm_pv = self._config['main'].get('xpm_pv', "NA")
         on_time_idx = self._engine1 * 4
         off_time_idx = (self._engine1 * 4) + 1
         all_shots_idx = (self._engine1 * 4) + 2
@@ -362,7 +362,9 @@ class LaserConfigDisplay(Display):
         return int(self.goose_rate_box.currentText())
 
     def update_goose_arrival(self):
-        cfgs = self._config['goose_arrival_configs']
+        cfgs = self._config.get('goose_arrival_configs', None)
+        if cfgs is None:
+            return
         if cfgs is not None:
             logger.debug(f"Goose arrival configs: {cfgs}")
             for name, cfg in cfgs.items():
@@ -457,12 +459,15 @@ class ExpertDisplay(Display):
         if self._config is None:
             raise ValueError(f"Could not read config file {config}")
 
-        if self._config is not None:
+        happi_db_path = self._config['main'].get('laser_database',None)
+        if happi_db_path is not None:
             self._db = happi.Client(
-                path=self._config['main']['laser_database']
+                path=happi_db_path
             )
+        else:
+            self._db = None
 
-        xpm_pv = self._config['main']['xpm_pv']
+        xpm_pv = self._config['main'].get('xpm_pv', "NA")
         self.xpm_table.set_channel(f"pva://{xpm_pv}:SEQCODES")
 
         self.configure_rbv_frames()
@@ -836,8 +841,9 @@ class UserConfigDisplay(Display):
             bay=self._config['main']['bay'],
         )
 
-        xpm_pv = self._config['main']['xpm_pv']
-        write_xpm_config(xpm_pv, self._engine1, seqdesc, instrset)
+        xpm_pv = self._config['main'].get('xpm_pv', None)
+        if xpm_pv is None:
+            write_xpm_config(xpm_pv, self._engine1, seqdesc, instrset)
 
     def apply_base_rates(self):
         """
@@ -852,9 +858,10 @@ class UserConfigDisplay(Display):
             offset=self.offset,
             bay=self._config['main']['bay'],
         )
-
-        xpm_pv = self._config['main']['xpm_pv']
-        write_xpm_config(xpm_pv, self._engine2, seqdesc, instrset)
+    
+        xpm_pv = self._config['main'].get('xpm_pv', None)
+        if xpm_pv is not None:
+            write_xpm_config(xpm_pv, self._engine2, seqdesc, instrset)
 
     def set_tic_enable(self, enable):
         """

--- a/opcpa_tpr_config/widgets.py
+++ b/opcpa_tpr_config/widgets.py
@@ -7,15 +7,13 @@ from os import path
 import happi
 import yaml
 from ophyd import EpicsSignal
-from psdaq.cas.pvedit import Pv
-from psdaq.seq.seqprogram import SeqUser
 from pydm import Display
 from pydm import widgets as pydm_widgets
 from qtpy import QtWidgets
 from xpm_prog import (allowed_goose_rates, sc_factors, nc_factors,
-                make_possible_rates,
-                make_base_sequence, make_sequence_sc,
-                make_sequence_nc, validate_goose_len
+                make_possible_rates, validate_goose_len,
+                build_laser_sequence, build_base_sequence,
+                write_xpm_config,
                 )
 
 logger = logging.getLogger(__name__)
@@ -665,12 +663,6 @@ class UserConfigDisplay(Display):
 
         self._engine1 = int(self._config['main']['engine1'])
         self._engine2 = int(self._config['main']['engine2'])
-        xpm_pv = self._config['main']['xpm_pv']
-
-        # Sequence engine for on/off time codes
-        self._LasSeq = SeqUser(f"{xpm_pv}:SEQENG:{self._engine1}")
-        # Sequence engine for base laser rate and diagnostic codes
-        self._BaseSeq = SeqUser(f"{xpm_pv}:SEQENG:{self._engine2}")
 
         self.screen_title.setText(self._config['main']['title'])
 
@@ -817,33 +809,35 @@ class UserConfigDisplay(Display):
         Generate and apply the XPM configuration for the laser on/off time
         event codes.
         """
+        try:
+            goose_len = int(self.laser_config_widget.goose_len_input.text())
+        except ValueError:
+            goose_len = 1
+        try:
+            goose_start = int(self.laser_config_widget.goose_start_input.text())
+        except ValueError:
+            goose_start = 1
 
-        fiducials_per_period = 910000 if self.is_superconducting else 120        
+        goose_rate = (
+            self.laser_config_widget.goose_rate
+            if self.laser_config_widget.goose_enabled
+            else None
+        )
 
-        base_div = fiducials_per_period//self.laser_config_widget.base_rate
-        if self.laser_config_widget.goose_enabled:
-            goose_div = fiducials_per_period//self.laser_config_widget.goose_rate
-        else:
-            goose_div = None
+        seqdesc, instrset = build_laser_sequence(
+            is_sc=self.is_superconducting,
+            base_rate=self.laser_config_widget.base_rate,
+            goose_rate=goose_rate,
+            goose_enabled=self.laser_config_widget.goose_enabled,
+            offset=self.offset,
+            start_ts1=self.laser_config_widget.start_ts1,
+            goose_len=goose_len,
+            goose_start=goose_start,
+            bay=self._config['main']['bay'],
+        )
 
-        logger.info("Applying laser rates")
-        logger.info(f"Base rate: {self.laser_config_widget.base_rate}")
-        logger.info(f"Goose rate: {self.laser_config_widget.goose_rate}")
-        logger.debug(f"Goose arrival: {self.laser_config_widget.arrival_config}")
-        logger.debug(f"Base div: {base_div}")
-        logger.debug(f"Goose div: {goose_div}")
-        logger.info(f"Offset: {self.offset}")
-
-        if self.is_superconducting:
-            instrset = make_sequence_sc(base_div, goose_div, self.offset)
-        else:
-            instrset = make_sequence_nc(base_div, self.laser_config_widget.start_ts1, goose_div) 
-
-        bay = self._config['main']['bay']
-        seqdesc = {0: f"{bay} On time shots", 1: f"{bay} Goose shots",
-                   2: f"{bay} All laser shots", 3: ""}
-
-        self.write_xpm_config(seqdesc, instrset, self._LasSeq, self._engine1)
+        xpm_pv = self._config['main']['xpm_pv']
+        write_xpm_config(xpm_pv, self._engine1, seqdesc, instrset)
 
     def apply_base_rates(self):
         """
@@ -853,43 +847,14 @@ class UserConfigDisplay(Display):
         logger.info("Applying base rates")
         logger.info(f"Offset: {self.offset}")
 
-        bay = self._config['main']['bay']
-        seqdesc = {0: f"{bay} 71.4kHz", 1: f"{bay} 35.7kHz", 2: f"{bay} 102Hz",
-                3: f"{bay} 5Hz"}
-
-        instrset = make_base_sequence(self.offset, firstSyncAC=(not self.is_superconducting))
-
-        self.write_xpm_config(seqdesc, instrset, self._BaseSeq, self._engine2)
-
-    def write_xpm_config(self, seqdesc, instrset, sequser, nengine):
-        """
-        Function to write a given XPM configuration to the specified engine.
-        """
-        seqcodes_pv = Pv(
-            f"{self._config['main']['xpm_pv']}:SEQCODES", isStruct=True
+        seqdesc, instrset = build_base_sequence(
+            is_sc=self.is_superconducting,
+            offset=self.offset,
+            bay=self._config['main']['bay'],
         )
-        seqcodes = seqcodes_pv.get()
-        desc = seqcodes.value.Description
 
-        sequser.execute('title', instrset, None, sync=True, refresh=False)
-
-        engineMask = 0
-        engineMask |= (1 << nengine)
-
-        for e in range(4*nengine, 4*nengine+4):
-            desc[e] = ''
-        for e, d in seqdesc.items():
-            desc[4*nengine+e] = d
-
-        tmo = 5.0  # EPICS PVA timeout
-
-        v = seqcodes.value
-        v.Description = desc
-        seqcodes.value = v
-        seqcodes_pv.put(seqcodes, wait=tmo)
-
-        pvSeqReset = Pv(f"{self._config['main']['xpm_pv']}:SeqReset")
-        pvSeqReset.put(engineMask, wait=tmo)
+        xpm_pv = self._config['main']['xpm_pv']
+        write_xpm_config(xpm_pv, self._engine2, seqdesc, instrset)
 
     def set_tic_enable(self, enable):
         """

--- a/opcpa_tpr_config/widgets.py
+++ b/opcpa_tpr_config/widgets.py
@@ -842,7 +842,7 @@ class UserConfigDisplay(Display):
         )
 
         xpm_pv = self._config['main'].get('xpm_pv', None)
-        if xpm_pv is None:
+        if xpm_pv is not None:
             write_xpm_config(xpm_pv, self._engine1, seqdesc, instrset)
 
     def apply_base_rates(self):

--- a/opcpa_tpr_config/widgets.py
+++ b/opcpa_tpr_config/widgets.py
@@ -13,7 +13,7 @@ from pydm import Display
 from pydm import widgets as pydm_widgets
 from qtpy import QtWidgets
 from xpm_prog import (allowed_goose_rates, sc_factors, nc_factors,
-                make_base_rates,
+                make_possible_rates,
                 make_base_sequence, make_sequence_sc,
                 make_sequence_nc
                 )
@@ -211,7 +211,7 @@ class LaserConfigDisplay(Display):
 
         self.update_pvs()
 
-        self._base_rates: list = make_base_rates(nc_factors)
+        self._base_rates: list = make_possible_rates(nc_factors)
         self.update_base_rates(False)
 
         self.update_goose_rates()
@@ -311,7 +311,7 @@ class LaserConfigDisplay(Display):
         else:
             factors = nc_factors
         
-        self._base_rates = make_base_rates(factors)
+        self._base_rates = make_possible_rates(factors)
         # Restrict allowed rates to > 1kHz for sc and >5hz for NC, but keep all rates in
         # self._base_rates for allowed goose rate calculation
         if is_superconducting:

--- a/opcpa_tpr_config/xpm_prog.py
+++ b/opcpa_tpr_config/xpm_prog.py
@@ -94,7 +94,7 @@ def make_sequence_sc(base_div, goose_div=None, goose_len=1, goose_start=1, offse
 
     return instrset
 
-def make_sequence_nc(base_div, goose_div=None, goose_len=1, goose_start=1, debug=False):
+def make_sequence_nc(base_div, start_ts1=True, goose_div=None, goose_len=1, goose_start=1, debug=False):
     """
     Generate an AC sequence at spacing of base_div times the base (120hz) rate for
     NC operation. 
@@ -135,8 +135,11 @@ def make_sequence_nc(base_div, goose_div=None, goose_len=1, goose_start=1, debug
     
     fiducial_marker = acRateHzToMarker["60Hz"] 
    
-    # always first sync to TS1 (might be handled in firmware, but leaving in just in case)
-    timeslot_mask = (1<<0) 
+    # first sync to starting timeslot
+    if start_ts1:
+        timeslot_mask = (1<<0)
+    else:
+        timeslot_mask = (1<<3)
     instrset.append(ACRateSync(timeslotm=timeslot_mask, marker=fiducial_marker, occ=1))
     logger.debug(f"ACRateSync(timeslotm={timeslot_mask}, marker={fiducial_marker}, occ=1)")
 
@@ -282,6 +285,95 @@ def _add_inner_sequence(instrset: list, offset=None, final=False):
     return instrset
 
 
+def write_xpm_config(xpm_pv: str, engine: int, seqdesc: dict, instrset: list) -> None:
+    """Write an XPM sequence configuration to the specified engine."""
+    seqcodes_pv = Pv(f'{xpm_pv}:SEQCODES', isStruct=True)
+    seqcodes = seqcodes_pv.get()
+    desc = seqcodes.value.Description
+
+    seq = SeqUser(f'{xpm_pv}:SEQENG:{engine}')
+    seq.execute('title', instrset, None, sync=True, refresh=False)
+
+    engineMask = 1 << engine
+
+    for e in range(4 * engine, 4 * engine + 4):
+        desc[e] = ''
+    for e, d in seqdesc.items():
+        desc[4 * engine + e] = d
+
+    tmo = 5.0  # EPICS PVA timeout
+
+    v = seqcodes.value
+    v.Description = desc
+    seqcodes.value = v
+    seqcodes_pv.put(seqcodes, wait=tmo)
+
+    pvSeqReset = Pv(f'{xpm_pv}:SeqReset')
+    pvSeqReset.put(engineMask, wait=tmo)
+
+
+def build_laser_sequence(
+    is_sc: bool,
+    base_rate: int,
+    goose_rate: int | None,
+    goose_enabled: bool,
+    offset: int,
+    start_ts1: bool = True,
+    goose_len: int = 1,
+    goose_start: int = 1,
+    bay: str = "",
+) -> tuple[dict, list]:
+    """Build the laser on/off time sequence and description."""
+    fiducials_per_period = 910000 if is_sc else 120
+    base_div = fiducials_per_period // base_rate
+
+    if goose_enabled and goose_rate is not None:
+        goose_div = fiducials_per_period // goose_rate
+    else:
+        goose_div = None
+
+    logger.info(f"Building laser sequence: base_rate={base_rate}, goose_rate={goose_rate}")
+    logger.debug(f"base_div={base_div}, goose_div={goose_div}, offset={offset}")
+
+    if is_sc:
+        instrset = make_sequence_sc(
+            base_div, goose_div=goose_div, goose_len=goose_len,
+            goose_start=goose_start, offset=offset,
+        )
+    else:
+        instrset = make_sequence_nc(
+            base_div, start_ts1=start_ts1, goose_div=goose_div,
+            goose_len=goose_len, goose_start=goose_start,
+        )
+
+    seqdesc = {
+        0: f"{bay} On time shots",
+        1: f"{bay} Goose shots",
+        2: f"{bay} All laser shots",
+        3: "",
+    }
+    return seqdesc, instrset
+
+
+def build_base_sequence(
+    is_sc: bool,
+    offset: int,
+    bay: str = "",
+) -> tuple[dict, list]:
+    """Build the base rate sequence and description."""
+    logger.info(f"Building base sequence: offset={offset}")
+
+    instrset = make_base_sequence(offset, firstSyncAC=(not is_sc))
+
+    seqdesc = {
+        0: f"{bay} 71.4kHz",
+        1: f"{bay} 35.7kHz",
+        2: f"{bay} 102Hz",
+        3: f"{bay} 5Hz",
+    }
+    return seqdesc, instrset
+
+
 def program_xpm(bay: int, engine: int, laser_rate: int, goose_rate: int, offset: int, xpm_pv="DAQ:DEH:XMP:0") -> None:
     """Build and program the XPM sequence for a given bay/engine."""
     base_list = make_possible_rates(sc_factors)
@@ -303,34 +395,11 @@ def program_xpm(bay: int, engine: int, laser_rate: int, goose_rate: int, offset:
     seqdesc = {0: f"Bay {bay} On Time", 1: f"Bay {bay} Off Time", 2: "", 3: ""}
     base_div = 910000 // int(laser_rate)
     goose_div = 910000 // int(goose_rate)
-    inst = make_sequence_sc(base_div, goose_div, offset, True)
+    inst = make_sequence_sc(base_div, goose_div=goose_div, offset=offset)
 
     logger.info(f"Programming XPM: bay={bay} engine={engine} laser_rate={laser_rate} goose_rate={goose_rate} offset={offset}")
 
-    seqcodes_pv = Pv(f'{xpm_pv}:SEQCODES', isStruct=True)
-    seqcodes = seqcodes_pv.get()
-    desc = seqcodes.value.Description
-
-    seq = SeqUser(f'{xpm_pv}:SEQENG:{engine}')
-    seq.execute('title', inst, None, sync=True, refresh=False)
-
-    engineMask = 0
-    engineMask |= (1 << engine)
-
-    for e in range(4 * engine, 4 * engine + 4):
-        desc[e] = ''
-    for e, d in seqdesc.items():
-        desc[4 * engine + e] = d
-
-    tmo = 5.0  # epics pva timeout
-
-    v = seqcodes.value
-    v.Description = desc
-    seqcodes.value = v
-    seqcodes_pv.put(seqcodes, wait=tmo)
-
-    pvSeqReset = Pv(f'{xpm_pv}:SeqReset')
-    pvSeqReset.put(engineMask, wait=tmo)
+    write_xpm_config(xpm_pv, engine, seqdesc, inst)
     logger.info("XPM programming complete")
 
 

--- a/opcpa_tpr_config/xpm_prog.py
+++ b/opcpa_tpr_config/xpm_prog.py
@@ -42,6 +42,8 @@ def allowed_goose_rates(laser_rate, rate_list):
 
 def validate_goose_len(base_div, goose_div, goose_len):
     """ Quick check for goose len to validate user input """
+    if goose_div is None:
+        return 1
     if goose_len < 1:
         return 1
     max_goose =   (goose_div//base_div) - 1

--- a/opcpa_tpr_config/xpm_prog.py
+++ b/opcpa_tpr_config/xpm_prog.py
@@ -1,7 +1,10 @@
 import argparse
 import itertools
+import logging
 
 import numpy as np
+
+logger = logging.getLogger(__name__)
 from psdaq.cas.pvedit import Pv
 from psdaq.seq.seq import Branch, ControlRequest, FixedRateSync, ACRateSync, acRateHzToMarker
 from psdaq.seq.seqprogram import SeqUser
@@ -39,52 +42,51 @@ def allowed_goose_rates(base_rate, rate_list):
 
 
 # Selected base rate + goose rate --> pulse sequence
-def make_sequence_sc(base_div, goose_div=None, offset=None, debug=False):
+def make_sequence_sc(base_div, goose_div=None, goose_len=1, goose_start=1, offset=None, debug=False):
     # Do some setup
     instrset = []
 
     # Insert bucket offset if it is present
     if offset is not None and offset != 0:
         instrset.append(FixedRateSync(marker="910kH", occ=offset))
-        if debug:
-            print(f"FixedRateSync(marker=\"910kH\", occ={offset})")
+        logger.debug(f"FixedRateSync(marker='910kH', occ={offset})")
 
-    # If we're goosing, put that pulse in _first_ because it makes delay
-    # management easier
-    if goose_div not in (None, 0):  # Start with goose
-        instrset.append(ControlRequest([1, 2]))
-        instrset.append(FixedRateSync(marker="910kH", occ=base_div))
-        if debug:
-            print("ControlRequest([1, 2])")
-            print(f"FixedRateSync(marker=\"910kH\", occ={base_div})")
+    #initial goose start offset
+    if goose_start > 1:
+        occ = base_div * (goose_len - 1)
+        instrset.append(FixedRateSync(marker="910kH", occ=occ))
+        logger.debug(f"FixedRateSync(marker='910kH', occ={occ})")
 
-    # Loop over base:goose rate ratio once. Because we're using divisors,
-    # we divide goose divider by base divider, rather than base rate by
-    # goose rate.
-    if goose_div in (None, 0):
-        n = 1
+    branch_0 = len(instrset)
+    if goose_div not in (None, 0):
+        # calculate ontime per goose
+        ontime_per_goose= (goose_div//base_div) - goose_len 
+         
+        # goosing shots are first, then # of ontime shots per goose
+        for i in range(goose_len):
+            instrset.append(ControlRequest([1, 2])) # goose + all
+            logger.debug("ControlRequest([1, 2])  # goose + all")
+            instrset.append(FixedRateSync(marker="910kH", occ=base_div))
+            logger.debug(f"FixedRateSync(marker='910kH', occ={base_div})")
+        for i in range(ontime_per_goose):
+            instrset.append(ControlRequest([0, 2])) # on_time + all
+            logger.debug("ControlRequest([0, 2])  # on_time + all")
+            instrset.append(FixedRateSync(marker="910kH", occ=base_div))
+            logger.debug(f"FixedRateSync(marker='910kH', occ={base_div})")
     else:
-        n = (goose_div//base_div) - 1
-    for i in range(n):
-        instrset.append(ControlRequest([0, 2]))
+        # no goose, only on_time shots
+        instrset.append(ControlRequest([0,2])) #on_time + all
+        logger.debug("ControlRequest([0, 2])  # on_time + all")
         instrset.append(FixedRateSync(marker="910kH", occ=base_div))
-        if debug:
-            print("ControlRequest([0, 2])")
-            print(f"FixedRateSync(marker=\"910kH\", occ={base_div})")
+        logger.debug(f"FixedRateSync(marker='910kH', occ={base_div})")
 
-    # Change branching based on offset
-    if offset is not None and offset != 0:
-        if debug:
-            print("Branch.unconditional(1)")
-        instrset.append(Branch.unconditional(1))
-    else:
-        if debug:
-            print("Branch.unconditional(0)")
-        instrset.append(Branch.unconditional(0))
+    # loop back to start
+    instrset.append(Branch.unconditional(line=branch_0))
+    logger.debug(f"Branch.unconditional(line={branch_0})")
 
     return instrset
 
-def make_sequence_nc(base_div, start_ts1 = True, goose_div=None, debug=False):
+def make_sequence_nc(base_div, goose_div=None, goose_len=1, goose_start=1, debug=False):
     """
     Generate an AC sequence at spacing of base_div times the base (120hz) rate for
     NC operation. 
@@ -123,37 +125,50 @@ def make_sequence_nc(base_div, start_ts1 = True, goose_div=None, debug=False):
     
     fiducial_marker = acRateHzToMarker["60Hz"] 
    
-    # sync the fist shot
-    if start_ts1:
-        timeslot_mask = (1<<0) 
-    else:
-        timeslot_mask = (1<<3)
+    # always first sync to TS1 (might be handled in firmware, but leaving in just in case)
+    timeslot_mask = (1<<0) 
     instrset.append(ACRateSync(timeslotm=timeslot_mask, marker=fiducial_marker, occ=1))
+    logger.debug(f"ACRateSync(timeslotm={timeslot_mask}, marker={fiducial_marker}, occ=1)")
 
     # Linac only fires on TS 1 and 4
     timeslot_mask = (1<<0) | (1<<3)
 
+    #initial offset for goose start
+    if goose_start > 1:
+        occ = base_div * (goose_start - 1)
+        instrset.append(ACRateSync(timeslotm=timeslot_mask, marker=fiducial_marker, occ=occ))
+        logger.debug(f"ACRateSync(timeslotm={timeslot_mask}, marker={fiducial_marker}, occ={occ})")
+ 
     branch_0 = len(instrset)
     if goose_div not in (None, 0):
-        # goosing
-        ontime_per_goose= (goose_div//base_div) - 1 
-        # goosing shot is first, then # of ontime shots per goose
-        instrset.append(ControlRequest([1, 2])) # goose + all
-        instrset.append(ACRateSync(timeslotm=timeslot_mask, marker=fiducial_marker, occ=base_div))
-        for i in range(ontime_per_goose):
-            instrset.append(ControlRequest([0, 2])) # on_time +all
+        # calculate ontime per goose
+        ontime_per_goose= (goose_div//base_div) - goose_len 
+         
+        # goosing shots are first, then # of ontime shots per goose
+        for i in range(goose_len):
+            instrset.append(ControlRequest([1, 2])) # goose + all
+            logger.debug("ControlRequest([1, 2])  # goose + all")
             instrset.append(ACRateSync(timeslotm=timeslot_mask, marker=fiducial_marker, occ=base_div))
-        instrset.append(Branch.unconditional(line=branch_0))
+            logger.debug(f"ACRateSync(timeslotm={timeslot_mask}, marker={fiducial_marker}, occ={base_div})")
+        for i in range(ontime_per_goose):
+            instrset.append(ControlRequest([0, 2])) # on_time + all
+            logger.debug("ControlRequest([0, 2])  # on_time + all")
+            instrset.append(ACRateSync(timeslotm=timeslot_mask, marker=fiducial_marker, occ=base_div))
+            logger.debug(f"ACRateSync(timeslotm={timeslot_mask}, marker={fiducial_marker}, occ={base_div})")
     else:
         # no goose, only on_time shots
         instrset.append(ControlRequest([0,2])) #on_time + all
+        logger.debug("ControlRequest([0, 2])  # on_time + all")
         instrset.append(ACRateSync(timeslotm=timeslot_mask, marker=fiducial_marker, occ=base_div))
-        instrset.append(Branch.unconditional(line=branch_0))
+        logger.debug(f"ACRateSync(timeslotm={timeslot_mask}, marker={fiducial_marker}, occ={base_div})")
 
-    if debug:
-        for instr in instrset:
-            print(instr.print_())
-        
+    # loop back to start
+    instrset.append(Branch.unconditional(line=branch_0))
+    logger.debug(f"Branch.unconditional(line={branch_0})")
+
+    for instr in instrset:
+        logger.debug(f"{instr.print_()}")
+
     return instrset
 
 
@@ -186,12 +201,15 @@ def make_base_sequence(offset=None, firstSyncAC=False):
         timeslot_mask = (1<<0) | (1<<3)
         fiducial_marker = acRateHzToMarker["60Hz"] 
         instrset.append(ACRateSync(timeslotm=timeslot_mask, marker=fiducial_marker, occ=1))
+        logger.debug(f"ACRateSync(timeslotm={timeslot_mask}, marker={fiducial_marker}, occ=1)")
         # needed so first offset_request() starts at a 70H marker
         instrset.append(FixedRateSync(marker="70kH", occ=2))
+        logger.debug("FixedRateSync(marker='70kH', occ=2)")
 
     branch_0 = len(instrset)
     _add_offset_request(instrset, [0, 1, 2, 3], offset) # 70kH + 35kH + 100H + 5H
     instrset.append(FixedRateSync(marker="70kH", occ=1))
+    logger.debug("FixedRateSync(marker='70kH', occ=1)")
     branch_1 = len(instrset)
     _add_inner_sequence(instrset, offset=offset)
 
@@ -200,10 +218,12 @@ def make_base_sequence(offset=None, firstSyncAC=False):
     spacing_5 = 14000
     loop_count = spacing_5 // spacing_100 - 2
     instrset.append(Branch.conditional(line=branch_1, counter=1, value=loop_count))
+    logger.debug(f"Branch.conditional(line={branch_1}, counter=1, value={loop_count})")
     # again last iteration has to be done manually
     _add_inner_sequence(instrset, offset=offset, final=True)
 
     instrset.append(Branch.unconditional(line=branch_0))
+    logger.debug(f"Branch.unconditional(line={branch_0})")
 
     return instrset
 
@@ -211,7 +231,9 @@ def _add_offset_request(instrset: list, request, offset) -> list:
     """ helper function adds control requests with appropriate offset"""
     if offset != 0:
         instrset.append(FixedRateSync(marker="910kH", occ=offset))
+        logger.debug(f"FixedRateSync(marker='910kH', occ={offset})")
     instrset.append(ControlRequest(request))
+    logger.debug(f"ControlRequest({request})")
 
 
 def _add_inner_sequence(instrset: list, offset=None, final=False):
@@ -233,83 +255,67 @@ def _add_inner_sequence(instrset: list, offset=None, final=False):
     branch = len(instrset)
     _add_offset_request(instrset, [0], offset) #70kH
     instrset.append(FixedRateSync(marker="70kH", occ=1))
+    logger.debug("FixedRateSync(marker='70kH', occ=1)")
     _add_offset_request(instrset, [0, 1], offset) #70kH + 35KH
     instrset.append(FixedRateSync(marker="70kH", occ=1))
+    logger.debug("FixedRateSync(marker='70kH', occ=1)")
     instrset.append(Branch.conditional(line=branch, counter=0, value=loop_count))
+    logger.debug(f"Branch.conditional(line={branch}, counter=0, value={loop_count})")
     # last iteration done manually since last iteration is different
     _add_offset_request(instrset, [0], offset) #70kH
     instrset.append(FixedRateSync(marker="70kH", occ=1))
+    logger.debug("FixedRateSync(marker='70kH', occ=1)")
     if not final:
         _add_offset_request(instrset, [0, 1, 2], offset) #70kH + 35KH + 100H
         instrset.append(FixedRateSync(marker="70kH", occ=1))
+        logger.debug("FixedRateSync(marker='70kH', occ=1)")
     return instrset
 
-if __name__ == "__main__":
-    parser = argparse.ArgumentParser()
+def plot_sequence(instrset: list) -> None:
+    """Plot the pulse sequence. TODO: implement visualization."""
+    logger.info("Plotting not yet implemented")
 
-    parser.add_argument(
-        "base_rate",
-        help="Desired laser output rep rate (total)"
-    )
-    parser.add_argument(
-        "goose_rate",
-        help="Desired laser goose rate (sub-harmonic of base_rate)")
-    parser.add_argument("offset", help="Desired 910 kHz bucket offset")
-    parser.add_argument("bay", help="Laser bay to program for (2 or 3)")
 
-    args = parser.parse_args()
-
-    base_rate = int(args.base_rate)
-    goose_rate = int(args.goose_rate)
-    offset = int(args.offset)
-
-    allowed_bays = [2, 3]
-    if int(args.bay) not in allowed_bays:
-        raise ValueError(f"Bay {args.bay} not in {allowed_bays}!")
-    else:
-        bay = int(args.bay)
-
-    engines = {2: 6, 3: 7}  # Bay --> sequence engine mapping
-
-    # Dict will eventually be applied to drop down menu
+def program_xpm(bay: int, engine: int, base_rate: int, goose_rate: int, offset: int) -> None:
+    """Build and program the XPM sequence for a given bay/engine."""
     base_list = make_base_rates(sc_factors)
 
     if base_rate not in base_list:
         raise ValueError(
-           ("Base rate {base_rate} is not one of the available laser "
-            f"rates: {base_list}")
+            f"Base rate {base_rate} is not one of the available laser "
+            f"rates: {base_list}"
         )
 
-    # Dict will eventually be applied to drop down menu
     goose_list = allowed_goose_rates(base_rate, base_list)
 
     if goose_rate not in goose_list:
         raise ValueError(
-           (f"Goose rate {goose_rate} is not one of the available goose "
-            f"rates: {goose_list}")
+            f"Goose rate {goose_rate} is not one of the available goose "
+            f"rates: {goose_list}"
         )
 
     seqdesc = {0: f"Bay {bay} On Time", 1: f"Bay {bay} Off Time", 2: "", 3: ""}
-    base_div = 910000//int(base_rate)
-    goose_div = 910000//int(goose_rate)
+    base_div = 910000 // int(base_rate)
+    goose_div = 910000 // int(goose_rate)
     inst = make_sequence_sc(base_div, goose_div, offset, True)
+
+    logger.info(f"Programming XPM: bay={bay} engine={engine} base_rate={base_rate} goose_rate={goose_rate} offset={offset}")
 
     xpm_pv = "DAQ:NEH:XPM:0"
     seqcodes_pv = Pv(f'{xpm_pv}:SEQCODES', isStruct=True)
     seqcodes = seqcodes_pv.get()
     desc = seqcodes.value.Description
 
-    engine = int(engines[bay])
     seq = SeqUser(f'{xpm_pv}:SEQENG:{engine}')
     seq.execute('title', inst, None, sync=True, refresh=False)
 
     engineMask = 0
     engineMask |= (1 << engine)
 
-    for e in range(4*engine, 4*engine+4):
+    for e in range(4 * engine, 4 * engine + 4):
         desc[e] = ''
     for e, d in seqdesc.items():
-        desc[4*engine+e] = d
+        desc[4 * engine + e] = d
 
     tmo = 5.0  # epics pva timeout
 
@@ -320,3 +326,95 @@ if __name__ == "__main__":
 
     pvSeqReset = Pv(f'{xpm_pv}:SeqReset')
     pvSeqReset.put(engineMask, wait=tmo)
+    logger.info("XPM programming complete")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="XPM sequence programmer")
+
+    parser.add_argument(
+        "base_rate", type=int,
+        help="Desired laser output rep rate (total)"
+    )
+    parser.add_argument(
+        "goose_rate", type=int,
+        help="Desired laser goose rate (sub-harmonic of base_rate)"
+    )
+    parser.add_argument(
+        "offset", type=int,
+        help="Desired 910 kHz bucket offset"
+    )
+    parser.add_argument(
+        "--bay", type=int, choices=[2, 3], default=None,
+        help="Laser bay to program (required unless --dry-run)"
+    )
+    parser.add_argument(
+        "--engine", type=int, default=None,
+        help="XPM sequence engine number (required unless --dry-run)"
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true", default=True,
+        help="Build sequence without programming hardware (default: True)"
+    )
+    parser.add_argument(
+        "--no-dry-run", dest="dry_run", action="store_false",
+        help="Actually program the XPM hardware"
+    )
+    parser.add_argument(
+        "--debug", action="store_true", default=True,
+        help="Enable debug-level log messages (default: True)"
+    )
+    parser.add_argument(
+        "--no-debug", dest="debug", action="store_false",
+        help="Disable debug-level log messages"
+    )
+    parser.add_argument(
+        "--plot", action="store_true", default=False,
+        help="Plot the generated pulse sequence"
+    )
+
+    args = parser.parse_args()
+
+    # Configure logging
+    log_level = logging.DEBUG if args.debug else logging.INFO
+    logging.basicConfig(
+        level=log_level,
+        format="%(asctime)s %(name)s [%(levelname)s] %(message)s",
+    )
+
+    # Validate bay/engine are provided when not dry-running
+    if not args.dry_run:
+        if args.bay is None or args.engine is None:
+            parser.error("--bay and --engine are required when not using --dry-run")
+
+    base_list = make_base_rates(sc_factors)
+
+    if args.base_rate not in base_list:
+        parser.error(
+            f"Base rate {args.base_rate} is not one of the available laser "
+            f"rates: {base_list}"
+        )
+
+    goose_list = allowed_goose_rates(args.base_rate, base_list)
+
+    if args.goose_rate not in goose_list:
+        parser.error(
+            f"Goose rate {args.goose_rate} is not one of the available goose "
+            f"rates: {goose_list}"
+        )
+
+    base_div = 910000 // args.base_rate
+    goose_div = 910000 // args.goose_rate
+    inst = make_sequence_sc(base_div, goose_div, args.offset, debug=args.debug)
+
+    logger.info(f"Generated sequence with {len(inst)} instructions")
+    for i, instr in enumerate(inst):
+        logger.debug(f"  [{i}] {instr}")
+
+    if args.plot:
+        plot_sequence(inst)
+
+    if args.dry_run:
+        logger.info("Dry run complete — no hardware programmed")
+    else:
+        program_xpm(args.bay, args.engine, args.base_rate, args.goose_rate, args.offset)

--- a/opcpa_tpr_config/xpm_prog.py
+++ b/opcpa_tpr_config/xpm_prog.py
@@ -14,7 +14,7 @@ sc_factors = [2, 2, 2, 5, 5, 5, 5, 7]  # 35000 (remove 13, 2, add 1)
 nc_factors = [2, 2, 2, 3, 5]# 120Hz  (independent of 910k factors)
 
 
-def make_base_rates(laser_factors):
+def make_possible_rates(laser_factors):
     """
     Generate a list of factors --> rates (TPG second)
     """
@@ -32,19 +32,27 @@ def make_base_rates(laser_factors):
     return sorted(list(f))
 
 
-def allowed_goose_rates(base_rate, rate_list):
+def allowed_goose_rates(laser_rate, rate_list):
     """
     Return a dict of allowed goose rates, based on the base rate of the laser
-    and a dictionary of allowed base rates created using make_base_rates().
+    and a dictionary of allowed base rates created using make_laser_rates().
     """
 
-    return [rate for rate in rate_list if rate < base_rate]
+    return [rate for rate in rate_list if rate < laser_rate]
 
+def validate_goose_len(base_div, goose_div, goose_len):
+    """ Quick check for goose len to validate user input """
+    if goose_len < 1:
+        return 1
+    max_goose =   (goose_div//base_div) - 1
+    return min(max_goose, goose_len)
 
 # Selected base rate + goose rate --> pulse sequence
 def make_sequence_sc(base_div, goose_div=None, goose_len=1, goose_start=1, offset=None, debug=False):
     # Do some setup
     instrset = []
+
+    goose_len = validate_goose_len(base_div,goose_div, goose_len)
 
     # Insert bucket offset if it is present
     if offset is not None and offset != 0:
@@ -122,6 +130,8 @@ def make_sequence_nc(base_div, goose_div=None, goose_len=1, goose_start=1, debug
  
     # Do some setup
     instrset = []
+
+    goose_len = validate_goose_len(base_div,goose_div, goose_len)
     
     fiducial_marker = acRateHzToMarker["60Hz"] 
    
@@ -271,22 +281,18 @@ def _add_inner_sequence(instrset: list, offset=None, final=False):
         logger.debug("FixedRateSync(marker='70kH', occ=1)")
     return instrset
 
-def plot_sequence(instrset: list) -> None:
-    """Plot the pulse sequence. TODO: implement visualization."""
-    logger.info("Plotting not yet implemented")
 
-
-def program_xpm(bay: int, engine: int, base_rate: int, goose_rate: int, offset: int) -> None:
+def program_xpm(bay: int, engine: int, laser_rate: int, goose_rate: int, offset: int, xpm_pv="DAQ:DEH:XMP:0") -> None:
     """Build and program the XPM sequence for a given bay/engine."""
-    base_list = make_base_rates(sc_factors)
+    base_list = make_possible_rates(sc_factors)
 
-    if base_rate not in base_list:
+    if laser_rate not in base_list:
         raise ValueError(
-            f"Base rate {base_rate} is not one of the available laser "
+            f"Base rate {laser_rate} is not one of the available laser "
             f"rates: {base_list}"
         )
 
-    goose_list = allowed_goose_rates(base_rate, base_list)
+    goose_list = allowed_goose_rates(laser_rate, base_list)
 
     if goose_rate not in goose_list:
         raise ValueError(
@@ -295,13 +301,12 @@ def program_xpm(bay: int, engine: int, base_rate: int, goose_rate: int, offset: 
         )
 
     seqdesc = {0: f"Bay {bay} On Time", 1: f"Bay {bay} Off Time", 2: "", 3: ""}
-    base_div = 910000 // int(base_rate)
+    base_div = 910000 // int(laser_rate)
     goose_div = 910000 // int(goose_rate)
     inst = make_sequence_sc(base_div, goose_div, offset, True)
 
-    logger.info(f"Programming XPM: bay={bay} engine={engine} base_rate={base_rate} goose_rate={goose_rate} offset={offset}")
+    logger.info(f"Programming XPM: bay={bay} engine={engine} laser_rate={laser_rate} goose_rate={goose_rate} offset={offset}")
 
-    xpm_pv = "DAQ:NEH:XPM:0"
     seqcodes_pv = Pv(f'{xpm_pv}:SEQCODES', isStruct=True)
     seqcodes = seqcodes_pv.get()
     desc = seqcodes.value.Description
@@ -333,16 +338,20 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="XPM sequence programmer")
 
     parser.add_argument(
-        "base_rate", type=int,
+        "--mode", type=str, choices=["sc", "nc"], default="sc",
+        help="Timing mode: 'sc' for superconducting (910kHz base), 'nc' for normal conducting (120Hz base) (default: sc)"
+    )
+    parser.add_argument(
+        "laser_rate", type=int, nargs="?", default=None,
         help="Desired laser output rep rate (total)"
     )
     parser.add_argument(
-        "goose_rate", type=int,
-        help="Desired laser goose rate (sub-harmonic of base_rate)"
+        "goose_rate", type=int, nargs="?", default=None,
+        help="Desired laser goose rate (sub-harmonic of laser_rate)"
     )
     parser.add_argument(
-        "offset", type=int,
-        help="Desired 910 kHz bucket offset"
+        "offset", type=int, nargs="?", default=0,
+        help="Desired 910 kHz bucket offset (default: 0)"
     )
     parser.add_argument(
         "--bay", type=int, choices=[2, 3], default=None,
@@ -369,8 +378,8 @@ if __name__ == "__main__":
         help="Disable debug-level log messages"
     )
     parser.add_argument(
-        "--plot", action="store_true", default=False,
-        help="Plot the generated pulse sequence"
+        "--list", action="store_true", default=False,
+        help="List possible base rates and exit"
     )
 
     args = parser.parse_args()
@@ -382,20 +391,43 @@ if __name__ == "__main__":
         format="%(asctime)s %(name)s [%(levelname)s] %(message)s",
     )
 
+    # Select rate factors and sequence builder based on mode
+    if args.mode == "sc":
+        rate_factors = sc_factors
+        clock_rate = 910000
+        make_sequence = make_sequence_sc
+    else:
+        rate_factors = nc_factors
+        clock_rate = 120
+        make_sequence = make_sequence_nc
+
+    base_list = make_possible_rates(rate_factors)
+
+    # --list: print possible rates and exit
+    if args.list:
+        print(f"Mode: {args.mode} (clock={clock_rate} Hz)")
+        print(f"Possible base rates (divisors): {base_list}")
+        if args.laser_rate is not None:
+            goose_list = allowed_goose_rates(args.laser_rate, base_list)
+            print(f"Possible goose rates for laser_rate={args.laser_rate}: {goose_list}")
+        raise SystemExit(0)
+
+    # Positional args are required when not just listing
+    if args.laser_rate is None or args.goose_rate is None:
+        parser.error("laser_rate and goose_rate are required (use --list to see options)")
+
     # Validate bay/engine are provided when not dry-running
     if not args.dry_run:
         if args.bay is None or args.engine is None:
             parser.error("--bay and --engine are required when not using --dry-run")
 
-    base_list = make_base_rates(sc_factors)
-
-    if args.base_rate not in base_list:
+    if args.laser_rate not in base_list:
         parser.error(
-            f"Base rate {args.base_rate} is not one of the available laser "
-            f"rates: {base_list}"
+            f"On-time rate {args.laser_rate} is not one of the available "
+            f"{args.mode} rates: {base_list}"
         )
 
-    goose_list = allowed_goose_rates(args.base_rate, base_list)
+    goose_list = allowed_goose_rates(args.laser_rate, base_list)
 
     if args.goose_rate not in goose_list:
         parser.error(
@@ -403,18 +435,15 @@ if __name__ == "__main__":
             f"rates: {goose_list}"
         )
 
-    base_div = 910000 // args.base_rate
-    goose_div = 910000 // args.goose_rate
-    inst = make_sequence_sc(base_div, goose_div, args.offset, debug=args.debug)
+    base_div = clock_rate // args.laser_rate
+    goose_div = clock_rate // args.goose_rate
+    inst = make_sequence(base_div, goose_div, offset=args.offset, debug=args.debug)
 
-    logger.info(f"Generated sequence with {len(inst)} instructions")
+    logger.info(f"Generated {args.mode} sequence with {len(inst)} instructions")
     for i, instr in enumerate(inst):
         logger.debug(f"  [{i}] {instr}")
-
-    if args.plot:
-        plot_sequence(inst)
 
     if args.dry_run:
         logger.info("Dry run complete — no hardware programmed")
     else:
-        program_xpm(args.bay, args.engine, args.base_rate, args.goose_rate, args.offset)
+        program_xpm(args.bay, args.engine, args.laser_rate, args.goose_rate, args.offset)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
-  Modify NC and SC sequences to allow N-in-M  goose shots vs on-time shots
    - reformatted the SC sequence to look more like the the NC  sequence
    - added better tests and visualizations simulations to confirm sequences
-  added configs for bay 1 (FEH:XPM)
- added a test_gui configuration
- did some refactoring/cleanup in widgets.py to move the XPM programming to the xpm_prog.py 


## Motivation and Context

[ECS-10645](https://jira.slac.stanford.edu/browse/ECS-10645)
XPP needs consecutive goose shots in sequences for multi-shot detectors


## How Has This Been Tested?
Completed Tests:
- ran test_sequences.py, confirmed total rate correct for most permutations of rates
- ran test_plot.py, confirmed a handfull of 120hz sequences
- ran and programmed FEH xpm, confirmed expected rate readbacks

Test Plan:
1. 6/17 test goose, onetime triggers on a scope, 
1.  Apply 3 different base rates, one with a goose trigger, confirming that the TPR in the laser locker sees the new rates.
2.  Apply and remove a start bucket offset that is different from xrays and confirm sync light works as expected.

## Where Has This Been Documented?
This PR. 


Screenshots:
<img width="927" height="1226" alt="image" src="https://github.com/user-attachments/assets/1386bde1-7a39-42d6-b512-72e69c0e0cb3" />

<img width="709" height="478" alt="image" src="https://github.com/user-attachments/assets/b5a9499a-8615-45cf-a50b-aca12e334ba7" />
<img width="693" height="565" alt="image" src="https://github.com/user-attachments/assets/7db3c733-5ab1-4b8b-8ce1-aa1be511dce5" />



## Pre-merge checklist
- [X] Code works interactively
- [X] Code contains descriptive docstrings, including context and API